### PR TITLE
Updated SFTPPathComponent properties to be public

### DIFF
--- a/Sources/Citadel/SFTP/SFTPMessage.swift
+++ b/Sources/Citadel/SFTP/SFTPMessage.swift
@@ -2,9 +2,9 @@ import NIO
 import Foundation
 
 public struct SFTPPathComponent {
-    let filename: String
-    let longname: String
-    let attributes: SFTPFileAttributes
+    public let filename: String
+    public let longname: String
+    public let attributes: SFTPFileAttributes
     
     public init(filename: String, longname: String, attributes: SFTPFileAttributes) {
         self.filename = filename


### PR DESCRIPTION
I was trying to list the files inside a directory and Xcode was complaining that SFTPPathComponent has filename, longname and attributes as internal only.

ps. Huge thanks for this framework, I'm trying to figure out if I can use it in one of my internal projects.