### PR TITLE
Change minimum deployment target to iOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Citadel",
     platforms: [
         .macOS(.v12),
-        .iOS(.v15)
+        .iOS(.v14)
     ],
     products: [
         .library(


### PR DESCRIPTION
I have tested this on iOS 14, and it works as expected. However, I have not had the opportunity to test it on iOS 13. Therefore I only updated the version in the Package.swift file to v14.