### PR TITLE
Add `inShell` parameter to for SSH command execution

### DIFF
--- a/Sources/Citadel/Algorithms/AES.swift
+++ b/Sources/Citadel/Algorithms/AES.swift
@@ -17,6 +17,7 @@ enum CitadelError: Error {
     case unauthorized
     case commandOutputTooLarge
     case channelCreationFailed
+    case shellRequestFailed
 }
 
 public final class AES128CTR: NIOSSHTransportProtection {

--- a/Sources/Citadel/Algorithms/AES.swift
+++ b/Sources/Citadel/Algorithms/AES.swift
@@ -17,7 +17,7 @@ enum CitadelError: Error {
     case unauthorized
     case commandOutputTooLarge
     case channelCreationFailed
-    case shellRequestFailed
+    case channelFailure
 }
 
 public final class AES128CTR: NIOSSHTransportProtection {

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -341,7 +341,7 @@ extension SSHClient {
         )
         
         try await channel.triggerUserOutboundEvent(execRequest)
-        
+        streamContinuation.finish()
         return stream
     }
 }

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -305,51 +305,43 @@ extension SSHClient {
         return ExecCommandStream(stdout: stdout, stderr: stderr)
     }
     
-    public func requestShell() async throws -> ByteBuffer {
-        let promise = eventLoop.makePromise(of: ByteBuffer.self)
-        
-        let channel: Channel
-        
-        do {
-            channel = try await eventLoop.flatSubmit {
-                let createChannel = self.eventLoop.makePromise(of: Channel.self)
-                self.session.sshHandler.createChannel(createChannel) { channel, _ in
-                    let collecting = CollectingExecCommandHelper(
-                        maxResponseSize: .max,
-                        stdoutPromise: promise,
-                        stderrPromise: nil,
-                        mergeStreams: false,
-                        allocator: channel.allocator
-                    )
-                    
-                    return channel.pipeline.addHandlers(
-                        ExecCommandHandler(logger: self.logger, onOutput: collecting.onOutput)
-                    )
-                }
-                
-                self.eventLoop.scheduleTask(in: .seconds(15)) {
-                    createChannel.fail(CitadelError.channelCreationFailed)
-                }
-                
-                return createChannel.futureResult
-            }.get()
-        } catch {
-            promise.fail(error)
-            throw error
+    public func requestShell() async throws -> AsyncThrowingStream<ExecCommandOutput, Error> {
+        var streamContinuation: AsyncThrowingStream<ExecCommandOutput, Error>.Continuation!
+        let stream = AsyncThrowingStream<ExecCommandOutput, Error> { continuation in
+            streamContinuation = continuation
         }
+        
+        let handler = ExecCommandHandler(logger: logger) { output in
+            switch output {
+            case .stdout(let stdout):
+                streamContinuation.yield(.stdout(stdout))
+            case .stderr(let stderr):
+                streamContinuation.yield(.stderr(stderr))
+            case .eof(let error):
+                streamContinuation.finish(throwing: error)
+            }
+        }
+        
+        let channel = try await eventLoop.flatSubmit {
+            let createChannel = self.eventLoop.makePromise(of: Channel.self)
+            self.session.sshHandler.createChannel(createChannel) { channel, _ in
+                channel.pipeline.addHandlers(handler)
+            }
+            
+            self.eventLoop.scheduleTask(in: .seconds(15)) {
+                createChannel.fail(CitadelError.channelCreationFailed)
+            }
+            
+            return createChannel.futureResult
+        }.get()
         
         // We need to exec a thing.
         let execRequest = SSHChannelRequestEvent.ShellRequest(
             wantReply: true
         )
         
-        return try await eventLoop.flatSubmit {
-            channel.triggerUserOutboundEvent(execRequest).whenFailure { [channel] error in
-                channel.close(promise: nil)
-                promise.fail(error)
-            }
-            
-            return promise.futureResult
-        }.get()
+        try await channel.triggerUserOutboundEvent(execRequest)
+        
+        return stream
     }
 }

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -252,6 +252,10 @@ extension SSHClient {
             return createChannel.futureResult
         }.get()
         
+        let shellRequest = SSHChannelRequestEvent.ShellRequest(wantReply: false)
+        
+        try await channel.triggerUserOutboundEvent(shellRequest)
+        
         // We need to exec a thing.
         let execRequest = SSHChannelRequestEvent.ExecRequest(
             command: command,
@@ -341,7 +345,6 @@ extension SSHClient {
         )
         
         try await channel.triggerUserOutboundEvent(execRequest)
-        streamContinuation.finish()
         return stream
     }
 }

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -267,21 +267,16 @@ extension SSHClient {
             return createChannel.futureResult
         }.get()
         
-        
-        let channelRequest: Any
         if inShell {
-            channelRequest = SSHChannelRequestEvent.ShellRequest(
+            try await channel.triggerUserOutboundEvent(SSHChannelRequestEvent.ShellRequest(
                 wantReply: true
-            )
-            
+            ))
         } else {
-            channelRequest = SSHChannelRequestEvent.ExecRequest(
+            try await channel.triggerUserOutboundEvent(SSHChannelRequestEvent.ExecRequest(
                 command: command,
                 wantReply: true
-            )
+            ))
         }
-
-        try await channel.triggerUserOutboundEvent(channelRequest)
         
         return stream
     }

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -132,6 +132,8 @@ final class ExecCommandHandler: ChannelDuplexHandler {
         switch event {
         case is NIOSSH.ChannelSuccessEvent:
             onOutput(context.channel, .channelSuccess)
+        case is NIOSSH.ChannelFailureEvent:
+            onOutput(context.channel, .eof(CitadelError.channelFailure))
         case is SSHChannelRequestEvent.ExitStatus:
             ()
         default:
@@ -165,11 +167,6 @@ final class ExecCommandHandler: ChannelDuplexHandler {
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         onOutput(context.channel, .eof(error))
     }
-
-//    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-//        let data = self.unwrapOutboundIn(data)
-//        context.write(self.wrapOutboundOut(SSHChannelData(type: .channel, data: .byteBuffer(data))), promise: promise)
-//    }
 }
 
 extension SSHClient {

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -252,6 +252,9 @@ extension SSHClient {
             return createChannel.futureResult
         }.get()
         
+        let shellRequest = SSHChannelRequestEvent.ShellRequest(wantReply: true)
+        try await channel.triggerUserOutboundEvent(shellRequest)
+        
         // We need to exec a thing.
         let execRequest = SSHChannelRequestEvent.ExecRequest(
             command: command,

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -283,6 +283,7 @@ extension SSHClient {
                 channel.close(promise: nil)
                 promise.fail(error)
             }
+            
             return promise.futureResult
         }.get()
     }
@@ -327,6 +328,7 @@ extension SSHClient {
         )
         
         try await channel.triggerUserOutboundEvent(execRequest)
+        
         return stream
     }
 
@@ -372,6 +374,9 @@ extension SSHClient {
         return ExecCommandStream(stdout: stdout, stderr: stderr)
     }
     
+    /// Requests a shell to be invoked and executes a command on the remote server.
+    /// - Parameters:
+    /// - command: The command to execute.
     public func executeInShell(command: String) async throws -> AsyncThrowingStream<ByteBuffer, Error> {
         var streamContinuation: AsyncThrowingStream<ByteBuffer, Error>.Continuation!
         let stream = AsyncThrowingStream<ByteBuffer, Error> { continuation in
@@ -403,7 +408,6 @@ extension SSHClient {
             return createChannel.futureResult
         }.get()
         
-        // We need to exec a thing.
         let shellRequest = SSHChannelRequestEvent.ShellRequest(
             wantReply: true
         )


### PR DESCRIPTION
This PR adds the option to execute commands in a shell, by launching a shell channel request and sending the command into the channel once the request succeeded.