### PR TITLE
Data race fix

### DIFF
--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -14,13 +14,15 @@ public final class SFTPClient {
     /// Causes a race condition
 //    private var nextRequestId: UInt32 = 0
     
-    private let syncQueue = DispatchQueue(label: "com.test.myQueue", attributes: .concurrent)
+//    private let syncQueue = DispatchQueue(label: "com.test.myQueue", attributes: .concurrent)
     private var _nextRequestId: UInt32 = 0
+    
+    @MainActor
     private func incrementAndGetNextRequestId() -> UInt32 {
-        syncQueue.sync {
-            self._nextRequestId &+= 1
-            return _nextRequestId
-        }
+//        syncQueue.sync {
+        self._nextRequestId &+= 1
+        return _nextRequestId
+//        }
     }
 //    var nextRequestId: UInt32 {
 //        get {
@@ -97,7 +99,7 @@ public final class SFTPClient {
     
     /// Returns a unique request ID for use in an SFTP message. Does _not_ register the ID for
     /// a response; that is handled by `sendRequest(_:)`.
-    internal func allocateRequestId() -> UInt32 {
+    @MainActor internal func allocateRequestId() -> UInt32 {
         return incrementAndGetNextRequestId()
 //        defer {
 //            self.nextRequestId &+= 1

--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -19,12 +19,15 @@ public final class SFTPClient {
     var nextRequestId: UInt32 {
         get {
             syncQueue.sync {
-                _nextRequestId
+                print("In grab. \(self._nextRequestId)")
+                return _nextRequestId
             }
         }
         set {
             syncQueue.async(flags: .barrier) {
+                print("In set. \(self._nextRequestId)")
                 self._nextRequestId = newValue
+                print("After set. \(self._nextRequestId)")
             }
         }
     }

--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -11,43 +11,13 @@ public final class SFTPClient {
     fileprivate let channel: Channel
     
     /// A monotonically increasing counter for gneerating request IDs.
-    /// Causes a race condition
-//    private var nextRequestId: UInt32 = 0
-    
-//    private let syncQueue = DispatchQueue(label: "com.test.myQueue", attributes: .concurrent)
     private var _nextRequestId: UInt32 = 0
     
     @MainActor
     private func incrementAndGetNextRequestId() -> UInt32 {
-//        syncQueue.sync {
         self._nextRequestId &+= 1
         return _nextRequestId
-//        }
     }
-//    var nextRequestId: UInt32 {
-//        get {
-//            syncQueue.async(flags: .barrier) {
-//                self.nextRequestId &+= 1
-//                return _nextRequestId
-//            }
-//        }
-////        get {
-////            syncQueue.sync {
-////                print("In grab. \(self._nextRequestId)")
-////                return _nextRequestId
-////            }
-////        }
-////        incrementAndGrab() -> UInt32 {
-////            self.nextRequestId &+= 1
-////        }
-////        set {
-////            syncQueue.async(flags: .barrier) {
-////                print("In set. \(self._nextRequestId)")
-////                self._nextRequestId = newValue
-////                print("After set. \(self._nextRequestId)")
-////            }
-////        }
-//    }
     
     /// In-flight request ID tracker.
     fileprivate let responses: SFTPResponses
@@ -101,10 +71,6 @@ public final class SFTPClient {
     /// a response; that is handled by `sendRequest(_:)`.
     @MainActor internal func allocateRequestId() -> UInt32 {
         return incrementAndGetNextRequestId()
-//        defer {
-//            self.nextRequestId &+= 1
-//        } syncQueue.sync {
-//        return self.nextRequestId
     }
     
     /// Sends an SFTP request. The request's ID is used to track the response.

--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -11,7 +11,23 @@ public final class SFTPClient {
     fileprivate let channel: Channel
     
     /// A monotonically increasing counter for gneerating request IDs.
-    private var nextRequestId: UInt32 = 0
+    /// Causes a race condition
+//    private var nextRequestId: UInt32 = 0
+    
+    private let syncQueue = DispatchQueue(label: "com.test.myQueue", attributes: .concurrent)
+    private var _nextRequestId: UInt32 = 0
+    var nextRequestId: UInt32 {
+        get {
+            syncQueue.sync {
+                _nextRequestId
+            }
+        }
+        set {
+            syncQueue.async(flags: .barrier) {
+                self._nextRequestId = newValue
+            }
+        }
+    }
     
     /// In-flight request ID tracker.
     fileprivate let responses: SFTPResponses


### PR DESCRIPTION
Was getting a data race issue when I started importing images on multiple threads. 

The error was `NIO-ELT-0-#0 (12): Assertion failed: Attempt to send request with request ID 35 already in flight.`. The code errored in SFTPClient within SendRequest on line 84 assert for `self.responses.responses[requestId] == nil`.

I made sure the `nextRequestId` was incremented on the main actor thread so we didn't get duplicate request IDs.