### PR TITLE
Add SFTP helper functions to retrieve the current working directory and obtain the real absolute path of a relative path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ To begin with SFTP, you must instantiate an SFTPClient based on your SSHClient:
 // Open an SFTP session on the SSH client
 let sftp = try await client.openSFTP()
 
+// Get the current working directory
+let cwd = try await sftp.getRealPath(atPath: ".")
+//Obtain the real path of the directory eg "/opt/vulscan/.. -> /opt"
+let truePath = try await sftp.getRealPath(atPath: "/opt/vulscan/..")
 // List the contents of the /etc directory
 let directoryContents = try await sftp.listDirectory(atPath: "/etc")
 

--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -284,6 +284,15 @@ public final class SFTPClient: Sendable {
         self.logger.debug("SFTP renamed file at \(oldPath) to \(newPath)")
     }
 
+    // Obtain the real path of the directory eg "/opt/vulscan/.. -> /opt" and Pass in ". "on initialization You can get the current working directory
+    public func getRealPath(atPath path: String) async throws -> String {
+        guard case let .name(realpath) = try await sendRequest(.realpath(.init(requestId: self.allocateRequestId(), path: path))) else {
+            self.logger.warning("SFTP server returned bad response to open file request, this is a protocol error")
+            throw SFTPError.invalidResponse
+        }
+        return realpath.path
+    }
+
 }
 
 extension SSHClient {


### PR DESCRIPTION
Added an sftp help function

1. Obtain the real path of the directory eg "/opt/vulscan/.. -> /opt" 
2. Pass in ". "on initialization You can get the current working directory