### PR TITLE
adds a test that illustrates #55 - env not getting set on remote execution with stream

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
-          "version": "5.3.0"
+          "revision": "114343a705df4725dfe7ab8a2a326b8883cfd79c",
+          "version": "5.5.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mtynior/ColorizeSwift.git",
         "state": {
           "branch": null,
-          "revision": "2a354639173d021f4648cf1912b2b00a3a7cd83c",
-          "version": "1.6.0"
+          "revision": "4e7daa138510b77a3cce9f6a31a116f8536347dd",
+          "version": "1.7.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-          "version": "1.1.0"
+          "revision": "671108c96644956dddcd89dd59c203dcdb36cec7",
+          "version": "1.1.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-          "version": "1.5.4"
+          "revision": "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
+          "version": "1.6.2"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "359c461e5561d22c6334828806cc25d759ca7aa6",
-          "version": "2.65.0"
+          "revision": "27c839f4700069928196cd0e9fa03b22f297078a",
+          "version": "2.78.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/Joannis/swift-nio-ssh.git",
         "state": {
           "branch": null,
-          "revision": "01e03b888734b03f1005b0ca329d7b5af50208e7",
-          "version": "0.3.2"
+          "revision": "0b3992e7acfdbf765aecd5e20bd8831d33d42453",
+          "version": "0.3.3"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-system.git",
         "state": {
           "branch": null,
-          "revision": "025bcb1165deab2e20d4eaba79967ce73013f496",
-          "version": "1.2.1"
+          "revision": "c8a44d836fe7913603e246acab7c528c2e780168",
+          "version": "1.4.0"
         }
       }
     ]


### PR DESCRIPTION
I ran across #55 and thought I'd try and verify it to start to debug it.

There's a lot in here that I'm not familiar with, but I thought first step would be to reproduce the issue in a test, so I tried to loosely replicate the issue in question interacting with the OpenSSH docker-service setup that's outlined in the CI with GH actions.

In addition to running the service locally using the command:

```bash
docker run -d -p 2222:2222 -e USER_NAME=citadel -e USER_PASSWORD=hunter2 -e PASSWORD_ACCESS=true lscr.io/linuxserver/openssh-server:latest
```

I invoked the tests with:
```bash
#!/usr/bin/env bash
set -eoux pipefail

export SWIFT_DETERMINISTIC_HASHING=1
export SSH_HOST=localhost
export SSH_PORT=2222
export SSH_USERNAME=citadel
export SSH_PASSWORD=hunter2

swift test
```