### PR TITLE
Fixed the build error when compiling with Swift static MUSL SDK on Linux.

### DIFF
--- a/Sources/CCitadelBcrypt/bcrypt-kdf.c
+++ b/Sources/CCitadelBcrypt/bcrypt-kdf.c
@@ -3,6 +3,7 @@
 
 #ifndef __APPLE__
 #include <sys/random.h>
+#include <unistd.h>
 #endif
 
 #include "bcrypt-kdf.h"


### PR DESCRIPTION
Fixed the missing `getentropy` function declaration when compiling with Swift static MUSL SDK on Linux.

Add `#include <unistd.h>` because in musl:

```
➜ grep -rn "getentropy" ./include/
./include/unistd.h:182:int getentropy(void *, size_t);
./include/c++/v1/__config:274://      Use getentropy().
```

before:

```
➜ swift build --swift-sdk x86_64-swift-linux-musl
[1/1] Planning build
Building for debugging...
/home/newamber/project/mine/mtvmm/.build/checkouts/Citadel/Sources/CCitadelBcrypt/bcrypt-kdf.c:162:5: error: call to undeclared function 'getentropy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  162 |     getentropy(key, keylen);
      |     ^
1 error generated.
[1/27] Write swift-version-5D5E3C4E9BE48293.txt

```

After:

```
➜ swift build --swift-sdk x86_64-swift-linux-musl
Building for debugging...
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
[7/7] Linking mtvmm
Build complete! (1.48s)
```