### PR TITLE
Move ColorizeSwift dependency to correct target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,13 +34,13 @@ let package = Package(
                 .product(name: "_CryptoExtras", package: "swift-crypto"),
                 .product(name: "BigInt", package: "BigInt"),
                 .product(name: "Logging", package: "swift-log"),
-                .productItem(name: "ColorizeSwift", package: "ColorizeSwift")
             ]
         ),
         .executableTarget(
             name: "CitadelServerExample",
             dependencies: [
-                "Citadel"
+                "Citadel",
+                .productItem(name: "ColorizeSwift", package: "ColorizeSwift")
             ]),
         .testTarget(
             name: "CitadelTests",


### PR DESCRIPTION
This dependency is just used in the example. It doesn't have to be in the main target.