### PR TITLE
fix visibility of SSHClientSettings.init and update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Citadel's `SSHClient` needs a connection to a SSH server first:
 ```swift
 let settings = SSHClientSettings(
     host: "example.com",
-    authenticationMethod: .passwordBased(username: "joannis", password: "s3cr3t"),
+    authenticationMethod: { .passwordBased(username: "joannis", password: "s3cr3t") },
     // Please use another validator if at all possible, it's insecure
     // But it's an easy way to try out Citadel
     hostKeyValidator: .acceptAnything()

--- a/Sources/Citadel/ClientSession.swift
+++ b/Sources/Citadel/ClientSession.swift
@@ -50,7 +50,7 @@ public struct SSHClientSettings: Sendable {
     internal var channelHandlers: [ChannelHandler & Sendable] = []
     public var connectTimeout: TimeAmount = .seconds(30)
 
-    init(
+    public init(
         host: String,
         port: Int = 22,
         authenticationMethod: @Sendable @escaping () -> SSHAuthenticationMethod,


### PR DESCRIPTION
Hi, this is a small change that should close https://github.com/orlandos-nl/Citadel/issues/106 by changing the visibility of `SSHClientSettings.init` to public so that it can be constructed from outside the Citadel module.

I also updated the usage instructions in the README to wrap the authentication method in a closure to match the signature of `init`. I'm just checking out Citadel and haven't dug deep yet, so let me know if there's anything I missed.