### PR TITLE
Increase allowed BCrypt rounds from 18 to 32

### DIFF
--- a/Sources/Citadel/OpenSSHKey.swift
+++ b/Sources/Citadel/OpenSSHKey.swift
@@ -443,7 +443,7 @@ extension OpenSSH.KDF {
             guard
                 let salt = options.readSSHBuffer(),
                 let rounds: UInt32 = options.readInteger(),
-                rounds < 18
+                rounds < 32
             else {
                 throw InvalidOpenSSHKey.invalidOrUnsupportedBCryptConfig
             }


### PR DESCRIPTION
Hi, thank you for this great package!

I noticed that when generating an OpenSSH key with a passphrase on my Mac, the default amount of iterations is 24:

```sh
ssh-keygen -t ed25519 -f ssh_key_with_passphrase -N "testpassphrase" -C "test key with passphrase"
```

However, Citadel doesn't support this key because in OpenSSHKey.swift the limit is set to 18 rounds, even though the underlying C code can handle more. Therefore I suggest increasing the limit to 32.