### PR TITLE
add `withExec` for 8-bit-safe SSH exec channels

### DIFF
--- a/Sources/Citadel/ChannelUnwrapper.swift
+++ b/Sources/Citadel/ChannelUnwrapper.swift
@@ -37,6 +37,22 @@ final class SSHOutboundChannelDataWrapper: ChannelOutboundHandler {
     }
 }
 
+final class SSHOutboundChannelDataUnwrapper: ChannelOutboundHandler {
+    typealias OutboundIn = SSHChannelData
+    typealias OutboundOut = ByteBuffer
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let data = self.unwrapOutboundIn(data)
+
+        guard case .byteBuffer(let bytes) = data.data else {
+            context.fireErrorCaught(SSHChannelError.invalidDataType)
+            return
+        }
+
+        context.write(self.wrapOutboundOut(bytes), promise: promise)
+    }
+}
+
 final class SSHInboundChannelDataWrapper: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = SSHChannelData

--- a/Sources/Citadel/Exec/Server/ExecHandler.swift
+++ b/Sources/Citadel/Exec/Server/ExecHandler.swift
@@ -129,7 +129,7 @@ final class ExecHandler: ChannelDuplexHandler {
                 }
                 var buffer = channel.allocator.buffer(capacity: data.count)
                 buffer.writeContiguousBytes(data)
-                channel.write(SSHChannelData(type: .stdErr, data: .byteBuffer(buffer)), promise: nil)
+                channel.writeAndFlush(SSHChannelData(type: .stdErr, data: .byteBuffer(buffer)), promise: nil)
             } catch {
                 channel.close(promise: nil)
             }

--- a/Sources/Citadel/Exec/Server/ExecHandler.swift
+++ b/Sources/Citadel/Exec/Server/ExecHandler.swift
@@ -139,7 +139,7 @@ final class ExecHandler: ChannelDuplexHandler {
             NIOPipeBootstrap(group: channel.eventLoop)
                 .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
                 .channelInitializer { pipeChannel in
-                    pipeChannel.pipeline.addHandlers(SSHInboundChannelDataWrapper(), theirs)
+                    pipeChannel.pipeline.addHandlers(SSHInboundChannelDataWrapper(), SSHOutboundChannelDataUnwrapper(), theirs)
                 }.withPipes(
                     inputDescriptor: dup(handler.stdoutPipe.fileHandleForReading.fileDescriptor),
                     outputDescriptor: dup(handler.stdinPipe.fileHandleForWriting.fileDescriptor)

--- a/Tests/CitadelTests/WithExecTests.swift
+++ b/Tests/CitadelTests/WithExecTests.swift
@@ -1,0 +1,151 @@
+@testable import Citadel
+import NIO
+@preconcurrency import NIOSSH
+import XCTest
+import Foundation
+
+@available(macOS 15.0, *)
+final class WithExecTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private struct TestTimeout: Error {}
+
+    private func runTest(
+        timeout: Duration = .seconds(5),
+        perform: @escaping (SSHServer, SSHClient) async throws -> Void
+    ) async throws {
+        let authDelegate = AuthDelegate(supportedAuthenticationMethods: .password) { request, promise in
+            switch request.request {
+            case .password(.init(password: "test")) where request.username == "citadel":
+                promise.succeed(.success)
+            default:
+                promise.succeed(.failure)
+            }
+        }
+        let server = try await SSHServer.host(
+            host: "localhost",
+            port: 0,
+            hostKeys: [NIOSSHPrivateKey(p521Key: .init())],
+            authenticationDelegate: authDelegate
+        )
+
+        let port = try XCTUnwrap(server.channel.localAddress?.port)
+
+        let client = try await SSHClient.connect(
+            host: "localhost",
+            port: port,
+            authenticationMethod: .passwordBased(username: "citadel", password: "test"),
+            hostKeyValidator: .acceptAnything(),
+            reconnect: .never
+        )
+
+        defer {
+            Task { try? await server.close() }
+        }
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await perform(server, client)
+                }
+                group.addTask {
+                    try await Task.sleep(for: timeout)
+                    throw TestTimeout()
+                }
+                // First to finish wins; cancel the other
+                try await group.next()
+                group.cancelAll()
+            }
+        } catch is TestTimeout {
+            XCTFail("Test timed out after \(timeout)")
+        } catch let error as ChannelError where error == .alreadyClosed {
+            // Server-initiated channel close can race with client close in withExec
+        }
+
+        do {
+            try await client.close()
+        } catch let error as ChannelError where error == .alreadyClosed {
+            // Already cleaned up
+        }
+    }
+
+    // MARK: - ExecHandler infrastructure tests
+    // These use public APIs other than withExec to show the fixes are
+    // necessary at the server handler level, not specific to one client API.
+
+    /// Stderr-only output is delivered via executeCommand.
+    /// Exercises the writeAndFlush fix: without it, stderr data sits in the
+    /// channel's write buffer and never reaches the client because nothing
+    /// triggers a flush.
+    func testExecuteCommandReceivesStderrOnly() async throws {
+        final class StderrOnly: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                DispatchQueue.global().async {
+                    let handle = outputHandler.stderrPipe.fileHandleForWriting
+                    handle.write(Data("only on stderr".utf8))
+                    try? handle.close()
+                    // No stdout at all — close it immediately
+                    try? outputHandler.stdoutPipe.fileHandleForWriting.close()
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = StderrOnly()
+            server.enableExec(withDelegate: execDelegate)
+
+            let result = try await client.executeCommand("test", mergeStreams: true)
+            XCTAssertEqual(String(buffer: result), "only on stderr")
+        }
+    }
+
+    /// Stderr arrives on the dedicated stderr stream of executeCommandPair.
+    /// Same underlying fix: without writeAndFlush the data never flushes.
+    func testExecuteCommandPairReceivesStderr() async throws {
+        final class StderrExec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                DispatchQueue.global().async {
+                    outputHandler.stderrPipe.fileHandleForWriting.write(Data("err".utf8))
+                    try? outputHandler.stderrPipe.fileHandleForWriting.close()
+                    outputHandler.stdoutPipe.fileHandleForWriting.write(Data("out".utf8))
+                    try? outputHandler.stdoutPipe.fileHandleForWriting.close()
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = StderrExec()
+            server.enableExec(withDelegate: execDelegate)
+
+            let streams = try await client.executeCommandPair("test")
+
+            var stdoutBuf = ByteBuffer()
+            for try await chunk in streams.stdout {
+                stdoutBuf.writeImmutableBuffer(chunk)
+            }
+
+            var stderrBuf = ByteBuffer()
+            for try await chunk in streams.stderr {
+                stderrBuf.writeImmutableBuffer(chunk)
+            }
+
+            XCTAssertEqual(String(buffer: stdoutBuf), "out")
+            XCTAssertEqual(String(buffer: stderrBuf), "err")
+        }
+    }
+}

--- a/Tests/CitadelTests/WithExecTests.swift
+++ b/Tests/CitadelTests/WithExecTests.swift
@@ -70,6 +70,209 @@ final class WithExecTests: XCTestCase {
         }
     }
 
+    // MARK: - Tests
+
+    /// Server writes known data to stdout; client receives it tagged as `.stdout`.
+    func testWithExecReceivesStdout() async throws {
+        final class Exec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                DispatchQueue.global().async {
+                    let handle = outputHandler.stdoutPipe.fileHandleForWriting
+                    handle.write(Data("hello stdout".utf8))
+                    try? handle.close()
+                    // Let NIO drain the pipe before succeed triggers pipeChannel.close
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = Exec()
+            server.enableExec(withDelegate: execDelegate)
+
+            try await client.withExec("test") { inbound, _ in
+                var collected = ByteBuffer()
+                for try await chunk in inbound {
+                    switch chunk {
+                    case .stdout(let buf):
+                        collected.writeImmutableBuffer(buf)
+                    case .stderr:
+                        XCTFail("Expected only stdout data")
+                    }
+                }
+                XCTAssertEqual(String(buffer: collected), "hello stdout")
+            }
+        }
+    }
+
+    /// Client writes data via outbound and server writes back a response on stdout.
+    /// Verifies both directions of the exec channel work in a single session.
+    func testWithExecBidirectionalIO() async throws {
+        final class Exec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            var receivedCommand: String?
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                receivedCommand = command
+                DispatchQueue.global().async {
+                    // Write a response on stdout (independent of stdin)
+                    let output = outputHandler.stdoutPipe.fileHandleForWriting
+                    output.write(Data("response from server".utf8))
+                    try? output.close()
+                    // Let NIO drain the pipe before succeed triggers pipeChannel.close
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = Exec()
+            server.enableExec(withDelegate: execDelegate)
+
+            try await client.withExec("my-command") { inbound, outbound in
+                // Client writes to stdin (verifies write doesn't crash)
+                try await outbound.write(ByteBuffer(string: "request from client"))
+
+                // Client reads stdout response
+                var collected = ByteBuffer()
+                for try await chunk in inbound {
+                    if case .stdout(let buf) = chunk {
+                        collected.writeImmutableBuffer(buf)
+                    }
+                }
+                XCTAssertEqual(String(buffer: collected), "response from server")
+            }
+
+            // Verify the command was forwarded correctly
+            XCTAssertEqual(execDelegate.receivedCommand, "my-command")
+        }
+    }
+
+    /// Binary data (all 256 byte values) is sent from server to client without mangling.
+    func testWithExecBinaryData() async throws {
+        let binaryPayload = Data(0...255)
+
+        final class BinaryExec: ExecDelegate, @unchecked Sendable {
+            let payload: Data
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            init(payload: Data) { self.payload = payload }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                let payload = self.payload
+                DispatchQueue.global().async {
+                    let output = outputHandler.stdoutPipe.fileHandleForWriting
+                    output.write(payload)
+                    try? output.close()
+                    // Let NIO drain the pipe before succeed triggers pipeChannel.close
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = BinaryExec(payload: binaryPayload)
+            server.enableExec(withDelegate: execDelegate)
+
+            try await client.withExec("cat") { inbound, _ in
+                var collected = ByteBuffer()
+                for try await chunk in inbound {
+                    if case .stdout(let buf) = chunk {
+                        collected.writeImmutableBuffer(buf)
+                    }
+                }
+                XCTAssertEqual(collected.readableBytes, 256)
+                XCTAssertEqual(collected.readBytes(length: 256), Array(binaryPayload))
+            }
+        }
+    }
+
+    /// Server writes to stderr pipe; client receives data tagged as `.stderr`.
+    func testWithExecReceivesStderr() async throws {
+        final class Exec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                DispatchQueue.global().async {
+                    let handle = outputHandler.stderrPipe.fileHandleForWriting
+                    handle.write(Data("error output".utf8))
+                    try? handle.close()
+                    try? outputHandler.stdoutPipe.fileHandleForWriting.close()
+                    // Let the readabilityHandler fire and flush before closing
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = Exec()
+            server.enableExec(withDelegate: execDelegate)
+
+            try await client.withExec("test") { inbound, _ in
+                var collected = ByteBuffer()
+                for try await chunk in inbound {
+                    switch chunk {
+                    case .stderr(let buf):
+                        collected.writeImmutableBuffer(buf)
+                    case .stdout:
+                        break
+                    }
+                }
+                XCTAssertEqual(String(buffer: collected), "error output")
+            }
+        }
+    }
+
+    /// When the `perform` closure throws, the error propagates and the channel closes.
+    func testWithExecClosesChannelOnError() async throws {
+        struct TestError: Error, Equatable {}
+
+        final class Exec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                DispatchQueue.global().async {
+                    try? outputHandler.stdoutPipe.fileHandleForWriting.close()
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = Exec()
+            server.enableExec(withDelegate: execDelegate)
+
+            do {
+                try await client.withExec("test") { _, _ in
+                    throw TestError()
+                }
+                XCTFail("Expected error to propagate")
+            } catch is TestError {
+                // Expected
+            }
+        }
+    }
+
     // MARK: - ExecHandler infrastructure tests
     // These use public APIs other than withExec to show the fixes are
     // necessary at the server handler level, not specific to one client API.
@@ -146,6 +349,95 @@ final class WithExecTests: XCTestCase {
 
             XCTAssertEqual(String(buffer: stdoutBuf), "out")
             XCTAssertEqual(String(buffer: stderrBuf), "err")
+        }
+    }
+
+    /// Stdin data written to the exec channel reaches the server process's pipe.
+    /// Exercises the SSHOutboundChannelDataUnwrapper fix in ExecHandler:
+    /// without it, SSHChannelData from the SSH channel can't be written to
+    /// the pipe channel (which expects ByteBuffer), so stdin never arrives.
+    func testExecStdinReachesServer() async throws {
+        final class StdinCapture: ExecDelegate, @unchecked Sendable {
+            private let lock = NSLock()
+            private var _stdinReceived: Data?
+            var stdinReceived: Data? { lock.withLock { _stdinReceived } }
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                let input = outputHandler.stdinPipe.fileHandleForReading
+                input.readabilityHandler = { [weak self] handle in
+                    let data = handle.availableData
+                    if !data.isEmpty {
+                        self?.lock.withLock { self?._stdinReceived = data }
+                    }
+                    handle.readabilityHandler = nil
+                }
+                DispatchQueue.global().async {
+                    let output = outputHandler.stdoutPipe.fileHandleForWriting
+                    output.write(Data("ack".utf8))
+                    try? output.close()
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = StdinCapture()
+            server.enableExec(withDelegate: execDelegate)
+
+            try await client.withExec("echo") { inbound, outbound in
+                try await outbound.write(ByteBuffer(string: "hello from stdin"))
+                for try await _ in inbound {}
+            }
+
+            XCTAssertEqual(
+                execDelegate.stdinReceived.flatMap { String(data: $0, encoding: .utf8) },
+                "hello from stdin"
+            )
+        }
+    }
+
+    // MARK: - withExec-specific tests
+
+    /// Environment variables are forwarded to the server delegate.
+    func testWithExecEnvironmentVariables() async throws {
+        final class Exec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            var receivedEnv: [String: String] = [:]
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {
+                receivedEnv[key] = value
+            }
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                DispatchQueue.global().async {
+                    try? outputHandler.stdoutPipe.fileHandleForWriting.close()
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = Exec()
+            server.enableExec(withDelegate: execDelegate)
+
+            try await client.withExec(
+                "test",
+                environment: [
+                    .init(wantReply: true, name: "FOO", value: "bar"),
+                    .init(wantReply: true, name: "BAZ", value: "qux"),
+                ]
+            ) { inbound, _ in
+                for try await _ in inbound {}
+            }
+
+            XCTAssertEqual(execDelegate.receivedEnv["FOO"], "bar")
+            XCTAssertEqual(execDelegate.receivedEnv["BAZ"], "qux")
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `SSHClient.withExec(_:environment:perform:)`, a structured concurrency API for bidirectional, 8-bit-safe exec channels
- Fixes two bugs in `ExecHandler` that prevented stderr-only output from reaching clients and stdin data from reaching server processes

## Motivation

The existing exec APIs (`executeCommand`, `executeCommandStream`, `executeCommandPair`) only support reading output. There's no way to write to stdin of a remote command without going through a PTY or shell session. PTY sessions process escape sequences and aren't 8-bit safe, making them unsuitable for binary data transfer. `withExec` fills this gap using a raw exec channel while exposing the same ergonomic closure-based API as `withTTY` and `withPTY`.

## Bug fixes

### Stderr writes not flushed

`ExecHandler` wrote stderr data to the SSH channel with `channel.write()` but never flushed it. The data only reached the client if stdout happened to flow through `GlueHandler` (which triggers `channelReadComplete` → `partnerFlush`). Processes that wrote only to stderr would hang forever on the client side.

**Fix:** `channel.write` → `channel.writeAndFlush` in `ExecHandler.swift`.

### Stdin not delivered to server process

The pipe channel pipeline was missing an outbound unwrapper. When the `GlueHandler` forwarded stdin data from the SSH channel to the pipe channel, it arrived as `SSHChannelData`, but the pipe channel expects `ByteBuffer`. Without a handler to convert between the two, stdin data was silently dropped.

**Fix:** Added `SSHOutboundChannelDataUnwrapper` to `ChannelUnwrapper.swift` and inserted it into the pipe channel pipeline in `ExecHandler.swift`.

## Changes

| File | Change |
|------|--------|
| `Sources/Citadel/Exec/Server/ExecHandler.swift` | `writeAndFlush` for stderr; added `SSHOutboundChannelDataUnwrapper` to pipe pipeline |
| `Sources/Citadel/ChannelUnwrapper.swift` | New `SSHOutboundChannelDataUnwrapper` handler |
| `Sources/Citadel/TTY/Client/TTY.swift` | New `SSHClient.withExec` public method |
| `Tests/CitadelTests/WithExecTests.swift` | 9 tests covering both bug fixes and the new API |

## API

```swift
@available(macOS 15.0, *)
public func withExec(
    _ command: String,
    environment: [SSHChannelRequestEvent.EnvironmentRequest] = [],
    perform: (_ inbound: TTYOutput, _ outbound: TTYStdinWriter) async throws -> Void
) async throws
```

## Test plan

All 9 tests pass. The infrastructure bug fix tests use existing public APIs (`executeCommand`, `executeCommandPair`) to demonstrate the fixes are necessary independent of `withExec`:

- [x] `testExecuteCommandReceivesStderrOnly`: stderr-only output via `executeCommand(mergeStreams: true)`
- [x] `testExecuteCommandPairReceivesStderr`: stderr + stdout via `executeCommandPair`
- [x] `testExecStdinReachesServer`: stdin data arrives at server process's pipe
- [x] `testWithExecReceivesStdout`: server writes stdout, client reads tagged `.stdout`
- [x] `testWithExecReceivesStderr`: server writes stderr, client reads tagged `.stderr`
- [x] `testWithExecBidirectionalIO`: client writes stdin, reads stdout response
- [x] `testWithExecBinaryData`: all 256 byte values pass through unmodified
- [x] `testWithExecClosesChannelOnError`: error in perform closure propagates and channel closes
- [x] `testWithExecEnvironmentVariables`: environment variables forwarded to server delegate
