### PR TITLE
Add listDirectoryStreaming for incremental readdir

### DIFF
--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -193,7 +193,84 @@ public final class SFTPClient: Sendable {
         
         return names
     }
-    
+
+    /// List the contents of a directory on the SFTP server, delivering each
+    /// batch of entries as it arrives from the server via `onBatch`.
+    ///
+    /// Unlike ``listDirectory(atPath:)`` which collects all readdir packets
+    /// before returning, this method invokes `onBatch` after each
+    /// `SSH_FXP_NAME` response, allowing the caller to process items
+    /// incrementally. This is especially useful for directories with many
+    /// files where you want to show progress or avoid accumulating all
+    /// entries in memory.
+    ///
+    /// - Parameters:
+    ///   - path: The path to list
+    ///   - onBatch: Called once per readdir packet with the entries from that
+    ///     packet. The `batchIndex` parameter is the zero-based ordinal of
+    ///     this packet.
+    /// - Returns: The total number of components received across all batches.
+    ///
+    /// ## Example
+    /// ```swift
+    /// let total = try await sftp.listDirectoryStreaming(atPath: "/home/user") { components, batchIndex in
+    ///     print("Batch \(batchIndex): \(components.count) items")
+    ///     for item in components {
+    ///         print(item.filename)
+    ///     }
+    /// }
+    /// print("Total files: \(total)")
+    /// ```
+    @discardableResult
+    public func listDirectoryStreaming(
+        atPath path: String,
+        onBatch: (_ components: [SFTPPathComponent], _ batchIndex: Int) throws -> Void
+    ) async throws -> Int {
+        var path = path
+        var oldPath: String
+
+        repeat {
+            oldPath = path
+            guard case .name(let realpath) = try await sendRequest(.realpath(.init(requestId: self.allocateRequestId(), path: path))) else {
+                self.logger.warning("SFTP server returned bad response to realpath request, this is a protocol error")
+                throw SFTPError.invalidResponse
+            }
+            path = realpath.path
+        } while path != oldPath
+
+        guard case .handle(let handle) = try await sendRequest(.opendir(.init(requestId: self.allocateRequestId(), handle: path))) else {
+            self.logger.warning("SFTP server returned bad response to opendir request, this is a protocol error")
+            throw SFTPError.invalidResponse
+        }
+
+        var totalComponents = 0
+        var batchIndex = 0
+        var response = try await sendRequest(
+            .readdir(
+                .init(
+                    requestId: self.allocateRequestId(),
+                    handle: handle.handle
+                )
+            )
+        )
+
+        while case .name(let name) = response {
+            totalComponents += name.components.count
+            try onBatch(name.components, batchIndex)
+            batchIndex += 1
+            response = try await sendRequest(
+                .readdir(
+                    .init(
+                        requestId: self.allocateRequestId(),
+                        handle: handle.handle
+                    )
+                )
+            )
+        }
+
+        return totalComponents
+    }
+
     /// Get the attributes of a file on the SFTP server.
     ///
     /// - Parameter filePath: Path to the file


### PR DESCRIPTION
## Summary

Adds `listDirectoryStreaming(atPath:onBatch:)` to `SFTPClient` — a streaming variant of `listDirectory(atPath:)` that delivers each batch of directory entries to a callback as they arrive from the server, rather than buffering the entire listing in memory.

This addresses #73 by providing callers a way to process large directory listings incrementally.

## Motivation

The existing `listDirectory(atPath:)` collects all `SSH_FXP_NAME` response packets into an array before returning. For directories with hundreds or thousands of files, this means:

- The caller must wait for the entire listing to complete before processing any entries
- All entries are held in memory simultaneously
- No way to show progress or render items incrementally in a UI

## API

```swift
@discardableResult
public func listDirectoryStreaming(
    atPath path: String,
    onBatch: (_ components: [SFTPPathComponent], _ batchIndex: Int) throws -> Void
) async throws -> Int
```

- `onBatch` is called once per `SSH_FXP_NAME` response packet (typically ~100 entries each)
- `batchIndex` is the zero-based ordinal of the current packet
- Returns the total component count across all batches
- The closure can throw to abort enumeration early

## Usage

```swift
let total = try await sftp.listDirectoryStreaming(atPath: "/home/user") { components, batchIndex in
    print("Batch \(batchIndex): \(components.count) items")
    for item in components {
        print(item.filename)
    }
}
print("Total files: \(total)")
```

## Implementation

Uses the same `sendRequest` flow as `listDirectory` (realpath → opendir → readdir loop), but invokes the callback after each readdir response instead of appending to an accumulator array. No changes to existing APIs or behavior.

## Testing

- Builds cleanly with `swift build`
- Tested in production in a macOS File Provider extension serving Finder directory listings over SFTP