### PR TITLE
Add withPTY(command:) — run a command on a PTY via an exec request

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ try await client.withPTY(
 }
 ```
 
+By default `withPTY` requests an interactive login shell. Pass `command:` to run a specific
+command on the PTY via an "exec" request instead (the `ssh -t host cmd` model) — the command is
+carried in the protocol packet, so it is never typed into or echoed by a remote shell:
+
+```swift
+try await client.withPTY(ptyRequest, command: "htop") { ttyOutput, ttyStdinWriter in
+    // ...interact with the running command...
+}
+```
+
 ### Jump Hosts
 
 Citadel supports jumping to another Host. First, connect to the jump host:

--- a/Sources/Citadel/TTY/Client/TTY.swift
+++ b/Sources/Citadel/TTY/Client/TTY.swift
@@ -263,7 +263,10 @@ extension SSHClient {
     }
 
     enum CommandMode {
-        case pty(SSHChannelRequestEvent.PseudoTerminalRequest), tty(command: String?), command(String)
+        // pty: `command == nil` requests a login shell ("shell" request); a non-nil command is
+        // sent as an "exec" request on the PTY channel (RFC 4254 §6.5, like `ssh -t host cmd`),
+        // so it runs without being typed into — or echoed by — the shell.
+        case pty(SSHChannelRequestEvent.PseudoTerminalRequest, command: String?), tty(command: String?), command(String)
     }
 
     internal func _executeCommandStream(
@@ -323,9 +326,18 @@ extension SSHClient {
         }
 
         switch mode {
-        case .pty(let request):
+        case .pty(let request, let command):
             try await channel.triggerUserOutboundEvent(request)
-            fallthrough
+            if let command {
+                try await channel.triggerUserOutboundEvent(SSHChannelRequestEvent.ExecRequest(
+                    command: command,
+                    wantReply: true
+                ))
+            } else {
+                try await channel.triggerUserOutboundEvent(SSHChannelRequestEvent.ShellRequest(
+                    wantReply: true
+                ))
+            }
         case .tty:
             try await channel.triggerUserOutboundEvent(SSHChannelRequestEvent.ShellRequest(
                 wantReply: true
@@ -343,18 +355,22 @@ extension SSHClient {
     /// Creates a pseudo-terminal (PTY) session and executes the provided closure with input/output streams
     /// - Parameters:
     ///   - request: PTY configuration parameters
+    ///   - command: Optional command to run on the PTY via an "exec" request (RFC 4254 §6.5),
+    ///     like `ssh -t host cmd`. The command is carried in the protocol packet — never typed
+    ///     into the shell, so it is not echoed. `nil` requests an interactive login shell.
     ///   - environment: Array of environment variables to set for the PTY session. This requires `PermitUserEnvironment` to be enabled in your OpenSSH server's configuration.
     ///   - perform: Closure that receives TTY input/output streams and performs terminal operations
     /// - Throws: Any errors that occur during PTY setup or operation
     @available(macOS 15.0, *)
     public func withPTY(
         _ request: SSHChannelRequestEvent.PseudoTerminalRequest,
+        command: String? = nil,
         environment: [SSHChannelRequestEvent.EnvironmentRequest] = [],
         perform: (_ inbound: TTYOutput, _ outbound: TTYStdinWriter) async throws -> Void
     ) async throws {
         let (channel, output) = try await _executeCommandStream(
             environment: environment,
-            mode: .pty(request)
+            mode: .pty(request, command: command)
         )
 
         func close() async throws {

--- a/Tests/CitadelTests/WithExecTests.swift
+++ b/Tests/CitadelTests/WithExecTests.swift
@@ -440,4 +440,61 @@ final class WithExecTests: XCTestCase {
             XCTAssertEqual(execDelegate.receivedEnv["BAZ"], "qux")
         }
     }
+
+    /// `withPTY(_:command:)` dispatches the command as an "exec" channel request (RFC 4254 §6.5,
+    /// the `ssh -t host cmd` model) instead of a "shell" request, so the command is carried in the
+    /// protocol packet rather than typed into (and echoed by) a remote shell.
+    func testWithPTYCommandSendsExecRequest() async throws {
+        final class Exec: ExecDelegate, @unchecked Sendable {
+            struct Ctx: ExecCommandContext {
+                func terminate() async throws {}
+            }
+            var receivedCommand: String?
+            func setEnvironmentValue(_ value: String, forKey key: String) async throws {}
+            func start(command: String, outputHandler: ExecOutputHandler) async throws -> ExecCommandContext {
+                receivedCommand = command
+                DispatchQueue.global().async {
+                    let handle = outputHandler.stdoutPipe.fileHandleForWriting
+                    handle.write(Data("interactive".utf8))
+                    try? handle.close()
+                    // Let NIO drain the pipe before succeed triggers pipeChannel.close
+                    Thread.sleep(forTimeInterval: 0.3)
+                    outputHandler.succeed(exitCode: 0)
+                }
+                return Ctx()
+            }
+        }
+
+        try await runTest { server, client in
+            let execDelegate = Exec()
+            server.enableExec(withDelegate: execDelegate)
+
+            // wantReply is false because the test server doesn't acknowledge pty-req;
+            // the exec request below is what's under test.
+            let ptyRequest = SSHChannelRequestEvent.PseudoTerminalRequest(
+                wantReply: false,
+                term: "xterm",
+                terminalCharacterWidth: 80,
+                terminalRowHeight: 24,
+                terminalPixelWidth: 0,
+                terminalPixelHeight: 0,
+                terminalModes: .init([.ECHO: 1])
+            )
+
+            try await client.withPTY(ptyRequest, command: "htop") { inbound, _ in
+                var collected = ByteBuffer()
+                for try await chunk in inbound {
+                    switch chunk {
+                    case .stdout(let buf):
+                        collected.writeImmutableBuffer(buf)
+                    case .stderr:
+                        XCTFail("Expected only stdout data")
+                    }
+                }
+                XCTAssertEqual(String(buffer: collected), "interactive")
+            }
+
+            XCTAssertEqual(execDelegate.receivedCommand, "htop")
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

`withPTY` currently pairs the `pty-req` with a `"shell"` channel request, so the only way to run a specific command under a PTY is to open an interactive shell and write the command into its stdin. Because the PTY has `ECHO` on, the line is echoed back by the remote shell before it runs — visible to the user in terminal UIs, and fragile in general (prompt detection, shell quoting, motd noise).

The SSH protocol supports running a command directly on a PTY channel: `pty-req` followed by an `"exec"` request (RFC 4254 §6.5). This is what `ssh -t host cmd` does — the command travels in the protocol packet and is never typed into or echoed by a shell. Citadel exposes `pty-req`+`shell` (`withPTY`) and plain `exec` (`withExec`), but not this combination.

## Changes

- `CommandMode.pty` gains an optional `command`; when set, `_executeCommandStream` sends an `ExecRequest` after the `pty-req` instead of a `ShellRequest`.
- `withPTY` gains `command: String? = nil`. `nil` keeps the existing interactive-shell behavior, so this is fully backward compatible (no call-site changes).
- Test: `testWithPTYCommandSendsExecRequest` verifies the command is dispatched to the server's `ExecDelegate` (i.e. arrives as an exec request, not shell stdin) and that output flows back.
- README: short note + example for the new parameter.

## Example

```swift
try await client.withPTY(ptyRequest, command: "htop") { inbound, outbound in
    // interact with the running command
}
```

Useful for terminal clients that need to launch a remote interactive program (or a wrapped login shell with injected environment, e.g. `env FOO=bar zsh -i`) without the bootstrap line appearing in the user's scrollback.