### PR TITLE
Add RFC 8332 rsa-sha2-256 / rsa-sha2-512 signature algorithms

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,97 +1,95 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "BigInt",
-        "repositoryURL": "https://github.com/attaswift/BigInt.git",
-        "state": {
-          "branch": null,
-          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
-          "version": "5.3.0"
-        }
-      },
-      {
-        "package": "ColorizeSwift",
-        "repositoryURL": "https://github.com/mtynior/ColorizeSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "2a354639173d021f4648cf1912b2b00a3a7cd83c",
-          "version": "1.6.0"
-        }
-      },
-      {
-        "package": "swift-asn1",
-        "repositoryURL": "https://github.com/apple/swift-asn1.git",
-        "state": {
-          "branch": null,
-          "revision": "f70225981241859eb4aa1a18a75531d26637c8cc",
-          "version": "1.4.0"
-        }
-      },
-      {
-        "package": "swift-atomics",
-        "repositoryURL": "https://github.com/apple/swift-atomics.git",
-        "state": {
-          "branch": null,
-          "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
-          "version": "1.3.0"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
-          "version": "3.12.3"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
-          "version": "1.5.4"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "ad6b5f17270a7008f60d35ec5378e6144a575162",
-          "version": "2.84.0"
-        }
-      },
-      {
-        "package": "swift-nio-ssh",
-        "repositoryURL": "https://github.com/Joannis/swift-nio-ssh.git",
-        "state": {
-          "branch": null,
-          "revision": "b93961a2988607a756cbc21a811f406f27aa9ab6",
-          "version": "0.3.4"
-        }
-      },
-      {
-        "package": "swift-system",
-        "repositoryURL": "https://github.com/apple/swift-system.git",
-        "state": {
-          "branch": null,
-          "revision": "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
-          "version": "1.5.0"
-        }
+  "pins" : [
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+        "version" : "5.3.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "colorizeswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mtynior/ColorizeSwift.git",
+      "state" : {
+        "revision" : "2a354639173d021f4648cf1912b2b00a3a7cd83c",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+        "version" : "3.12.3"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "ad6b5f17270a7008f60d35ec5378e6144a575162",
+        "version" : "2.84.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssh",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Wellz26/swift-nio-ssh.git",
+      "state" : {
+        "revision" : "b93961a2988607a756cbc21a811f406f27aa9ab6",
+        "version" : "0.3.4"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Sources/Citadel/Algorithms/RSASHA2.swift
+++ b/Sources/Citadel/Algorithms/RSASHA2.swift
@@ -1,0 +1,166 @@
+import NIO
+import NIOSSH
+import CCryptoBoringSSL
+import Foundation
+import Crypto
+
+// RFC 8332 signature algorithms for RSA keys: `rsa-sha2-256` / `rsa-sha2-512`.
+//
+// Citadel's `Insecure.RSA` types sign with SHA-1 and name themselves `ssh-rsa`.
+// OpenSSH 8.8 (2021) dropped `ssh-rsa` from the default
+// PubkeyAcceptedAlgorithms, so an RSA key can no longer authenticate against a
+// stock modern server. The key material is identical - only the signature hash
+// and the algorithm name change - so these types wrap the existing key and
+// re-label it.
+
+/// Hash variant for an RFC 8332 RSA signature.
+public protocol RSASHA2Variant: Sendable {
+    /// Wire name, used both as the public key algorithm and the signature type.
+    static var algorithmName: String { get }
+    /// BoringSSL NID for the digest.
+    static var nid: Int32 { get }
+    static func digest<D: DataProtocol>(_ data: D) -> [UInt8]
+}
+
+public enum RSASHA2_256: RSASHA2Variant {
+    public static let algorithmName = "rsa-sha2-256"
+    public static let nid = NID_sha256
+    public static func digest<D: DataProtocol>(_ data: D) -> [UInt8] {
+        Array(SHA256.hash(data: Data(data)))
+    }
+}
+
+public enum RSASHA2_512: RSASHA2Variant {
+    public static let algorithmName = "rsa-sha2-512"
+    public static let nid = NID_sha512
+    public static func digest<D: DataProtocol>(_ data: D) -> [UInt8] {
+        Array(SHA512.hash(data: Data(data)))
+    }
+}
+
+extension Insecure.RSA {
+
+    /// An RSA signature carrying an RFC 8332 algorithm name.
+    public struct SHA2Signature<Variant: RSASHA2Variant>: ContiguousBytes, NIOSSHSignatureProtocol {
+        public static var signaturePrefix: String { Variant.algorithmName }
+
+        public let rawRepresentation: Data
+
+        public init<D>(rawRepresentation: D) where D: DataProtocol {
+            self.rawRepresentation = Data(rawRepresentation)
+        }
+
+        public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+            try rawRepresentation.withUnsafeBytes(body)
+        }
+
+        public func write(to buffer: inout ByteBuffer) -> Int {
+            buffer.writeSSHString(rawRepresentation)
+        }
+
+        public static func read(from buffer: inout ByteBuffer) throws -> Self {
+            guard let buffer = buffer.readSSHBuffer() else {
+                throw RSAError(message: "Invalid signature format")
+            }
+            return .init(rawRepresentation: buffer.getData(at: 0, length: buffer.readableBytes)!)
+        }
+    }
+
+    /// The same RSA public key (`e`, `n` on the wire) under an RFC 8332 name.
+    public final class SHA2PublicKey<Variant: RSASHA2Variant>: NIOSSHPublicKeyProtocol {
+        public static var publicKeyPrefix: String { Variant.algorithmName }
+
+        internal let base: PublicKey
+
+        internal init(base: PublicKey) {
+            self.base = base
+        }
+
+        public var rawRepresentation: Data { base.rawRepresentation }
+
+        /// Wire body is identical to `ssh-rsa`: mpint e, mpint n. Only the
+        /// algorithm name written around it differs.
+        public func write(to buffer: inout ByteBuffer) -> Int {
+            base.write(to: &buffer)
+        }
+
+        public static func read(from buffer: inout ByteBuffer) throws -> Self {
+            .init(base: try PublicKey.read(from: &buffer))
+        }
+
+        public func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignatureProtocol, for data: D) -> Bool {
+            guard let signature = signature as? SHA2Signature<Variant> else { return false }
+
+            let context = CCryptoBoringSSL_RSA_new()
+            defer { CCryptoBoringSSL_RSA_free(context) }
+
+            // Copy: RSA_free would otherwise free the key's own bignums.
+            let modulus = CCryptoBoringSSL_BN_new()!
+            let publicExponent = CCryptoBoringSSL_BN_new()!
+            CCryptoBoringSSL_BN_copy(modulus, base.modulus)
+            CCryptoBoringSSL_BN_copy(publicExponent, base.publicExponent)
+            guard CCryptoBoringSSL_RSA_set0_key(context, modulus, publicExponent, nil) == 1 else {
+                return false
+            }
+
+            let digest = Variant.digest(data)
+            let signatureBytes = Array(signature.rawRepresentation)
+            return CCryptoBoringSSL_RSA_verify(
+                Variant.nid,
+                digest,
+                digest.count,
+                signatureBytes,
+                signatureBytes.count,
+                context
+            ) == 1
+        }
+    }
+
+    /// An RSA private key that signs with SHA-2 and offers itself as
+    /// `rsa-sha2-256` / `rsa-sha2-512`.
+    public final class SHA2PrivateKey<Variant: RSASHA2Variant>: NIOSSHPrivateKeyProtocol {
+        public static var keyPrefix: String { Variant.algorithmName }
+
+        private let base: PrivateKey
+
+        public init(_ base: PrivateKey) {
+            self.base = base
+        }
+
+        public var publicKey: NIOSSHPublicKeyProtocol {
+            SHA2PublicKey<Variant>(base: base._publicKey)
+        }
+
+        public func signature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+            let context = CCryptoBoringSSL_RSA_new()
+            defer { CCryptoBoringSSL_RSA_free(context) }
+
+            let modulus = CCryptoBoringSSL_BN_new()!
+            let publicExponent = CCryptoBoringSSL_BN_new()!
+            let privateExponent = CCryptoBoringSSL_BN_new()!
+            CCryptoBoringSSL_BN_copy(modulus, base._publicKey.modulus)
+            CCryptoBoringSSL_BN_copy(publicExponent, base._publicKey.publicExponent)
+            CCryptoBoringSSL_BN_copy(privateExponent, base.privateExponent)
+            guard CCryptoBoringSSL_RSA_set0_key(context, modulus, publicExponent, privateExponent) == 1 else {
+                throw CitadelError.signingError
+            }
+
+            let digest = Variant.digest(data)
+            let out = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+            defer { out.deallocate() }
+            var outLength: UInt32 = 4096
+            guard CCryptoBoringSSL_RSA_sign(
+                Variant.nid,
+                digest,
+                digest.count,
+                out,
+                &outLength,
+                context
+            ) == 1 else {
+                throw CitadelError.signingError
+            }
+
+            return SHA2Signature<Variant>(rawRepresentation: Data(bytes: out, count: Int(outLength)))
+        }
+    }
+}

--- a/Sources/Citadel/SSHAuthenticationMethod.swift
+++ b/Sources/Citadel/SSHAuthenticationMethod.swift
@@ -26,7 +26,17 @@ public final class SSHAuthenticationMethod: NIOSSHClientUserAuthenticationDelega
         self.allImplementations = [.custom(custom)]
         self.implementations = allImplementations
     }
-    
+
+    /// Offers are tried in order: each one is used when the server rejects the
+    /// previous. Lets a key be offered under several signature algorithms.
+    internal init(
+        username: String,
+        offers: [NIOSSHUserAuthenticationOffer.Offer]
+    ) {
+        self.allImplementations = offers.map { .user(username, offer: $0) }
+        self.implementations = allImplementations
+    }
+
     /// Creates a password based authentication method.
     /// - Parameters:
     ///  - username: The username to authenticate with.
@@ -42,7 +52,34 @@ public final class SSHAuthenticationMethod: NIOSSHClientUserAuthenticationDelega
     public static func rsa(username: String, privateKey: Insecure.RSA.PrivateKey) -> SSHAuthenticationMethod {
         return SSHAuthenticationMethod(username: username, offer: .privateKey(.init(privateKey: .init(custom: privateKey))))
     }
-    
+
+    /// Public key authentication with an RSA key, using the RFC 8332 SHA-2
+    /// signature algorithms.
+    ///
+    /// `ssh-rsa` (SHA-1) has been off by default in OpenSSH's
+    /// `PubkeyAcceptedAlgorithms` since 8.8, so `rsa(username:privateKey:)`
+    /// cannot authenticate against a stock modern server. This offers
+    /// `rsa-sha2-512` then `rsa-sha2-256`, and finally plain `ssh-rsa` when
+    /// `includeSHA1Fallback` is set, for servers predating RFC 8332.
+    /// - Parameters:
+    ///   - username: The username to authenticate with.
+    ///   - privateKey: The RSA private key to authenticate with.
+    ///   - includeSHA1Fallback: Also offer legacy `ssh-rsa`. Defaults to `true`.
+    public static func rsaSHA2(
+        username: String,
+        privateKey: Insecure.RSA.PrivateKey,
+        includeSHA1Fallback: Bool = true
+    ) -> SSHAuthenticationMethod {
+        var offers: [NIOSSHUserAuthenticationOffer.Offer] = [
+            .privateKey(.init(privateKey: .init(custom: Insecure.RSA.SHA2PrivateKey<RSASHA2_512>(privateKey)))),
+            .privateKey(.init(privateKey: .init(custom: Insecure.RSA.SHA2PrivateKey<RSASHA2_256>(privateKey)))),
+        ]
+        if includeSHA1Fallback {
+            offers.append(.privateKey(.init(privateKey: .init(custom: privateKey))))
+        }
+        return SSHAuthenticationMethod(username: username, offers: offers)
+    }
+
     /// Creates a public key based authentication method.
     /// - Parameters: 
     /// - username: The username to authenticate with.

--- a/Tests/CitadelTests/RSASHA2Tests.swift
+++ b/Tests/CitadelTests/RSASHA2Tests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+import Crypto
+import Citadel
+import NIO
+import NIOSSH
+
+/// RFC 8332 (`rsa-sha2-256` / `rsa-sha2-512`) signatures for RSA keys.
+final class RSASHA2Tests: XCTestCase {
+
+    private func makeKey() throws -> Insecure.RSA.PrivateKey {
+            let key = """
+                -----BEGIN OPENSSH PRIVATE KEY-----
+                b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
+                NhAAAAAwEAAQAAAYEAw/gR2vricwFOwsiq41CAZ3agb8jeuLb6xBrSIf1yBKt0SF84Xod8
+                ggYwBHN2KpbKPG61WtG0VcngxGi2JizGLSUunWSv1alMQxUCzO8OzhLEDo2aB9R/mlulug
+                P68jGlpOdKL8ObocG8wtmmocYr4DL2gxa2MX3LeGVKXCuzViVBro4hfL2VkIZykPdSFBgi
+                +tO/qol7uCrmSuibm/Ajmel6Q7I0gA3ItC3j3ILS39lwL8CEJVcoxaupfSXvOyzm+UzNBN
+                Oi4Qvtk6w0xga2dRDhE2ANDSR1bVDTVMP/k/DJJCGP6t+ix5NGplrdNa3ue3AsU6SmbUaY
+                gSgDBSpSxqRakbW3fReAgplwzZ/1hy8Uq2haT+XGjLdT9JOF5xKuQEUABAJ2ZPVrrd49Cx
+                7/EuR6w1Dp27PhZIrF8AIAld8ayiZvVy+ALME4Vvp91y86VSdxC97TmBYUErhMMaQ5LaD0
+                S1bB/8qTt6oEQGBPISMeyi+n9r6UAP+InEnHE32HAAAFmAbVXc8G1V3PAAAAB3NzaC1yc2
+                EAAAGBAMP4Edr64nMBTsLIquNQgGd2oG/I3ri2+sQa0iH9cgSrdEhfOF6HfIIGMARzdiqW
+                yjxutVrRtFXJ4MRotiYsxi0lLp1kr9WpTEMVAszvDs4SxA6NmgfUf5pbpboD+vIxpaTnSi
+                /Dm6HBvMLZpqHGK+Ay9oMWtjF9y3hlSlwrs1YlQa6OIXy9lZCGcpD3UhQYIvrTv6qJe7gq
+                5krom5vwI5npekOyNIANyLQt49yC0t/ZcC/AhCVXKMWrqX0l7zss5vlMzQTTouEL7ZOsNM
+                YGtnUQ4RNgDQ0kdW1Q01TD/5PwySQhj+rfoseTRqZa3TWt7ntwLFOkpm1GmIEoAwUqUsak
+                WpG1t30XgIKZcM2f9YcvFKtoWk/lxoy3U/SThecSrkBFAAQCdmT1a63ePQse/xLkesNQ6d
+                uz4WSKxfACAJXfGsomb1cvgCzBOFb6fdcvOlUncQve05gWFBK4TDGkOS2g9EtWwf/Kk7eq
+                BEBgTyEjHsovp/a+lAD/iJxJxxN9hwAAAAMBAAEAAAGBAK/bXlKPD0U66C3dm5SPehrelk
+                yaClviQBhZJTbBVF8iaSBE6rXRiYa4/MARyPmhBWzDwFT2mIjft6cpfEO3rEN4+WLepvfq
+                i/gq06+J21RL/Mo+gfoC1Ft1YLwTtE9BBC9+KtHADFpVHAoS/PhxeJAhy5uJdwfkpgGti9
+                Q4lx94IX/+Jcjl7GCcdhTnDC3iFwnVmUr1QyPaw3x3TqTaE2ib307+jSRYukIOaEtKzud4
+                HbeMYEmN9JWmXVtj/lGxESN96JCZaCf9f8QPRcjjHOIHQ5RXa8XRUDpg/ngCqv3U1c8bdy
+                Ty1WFToZSt/nBz8qs89dfz9AqlQcbg7bvGxdQS5pMrzPar6Irn8rbEnN4YL569Ng5FEAui
+                AmeXoqwMlIXzkNfwE4lQBMJJFGHIQFILC+ttTQiHVAp5wJ6KL1b4rF40YFZzjj9HmCPJKZ
+                BP67dtd6F6DsllPqU4dbuI/4jOVg9boS985r/EhZSAqUtR3RC1KLS6bUO7AOKMfTGTKQAA
+                AMBeBBbAR0qpLXlwCybGUA34xiCu5mwSvTdzD/1aMyy0n7ebBuPL0bPQ0laeQCHqflQgm6
+                nX0qLpGaQIPKF0HSdukr2KKVzEuPgdEuP6Tr7sdZ87Sl8WlVi2P9zDxNpHAizFYnxXb9ft
+                xaIHSu3BWNWuALt30Mn9RaX1MjV6+lanZKsniQ1cWiW1McJY39TyqL+KMzgJ/9S351wzri
+                R29j1MwV0P/Azu+yoji0015UN/A7ydnPGHrHu0Pd8bu0itSiUAAADBAP3vVOu78XQdBOvo
+                /dObSirz3UEbKZIaA7eYq61lbfRy+IYo+5Q5huf3mcCMeqOA4rItKu7PCIHNDbQ//h2H+X
+                AH0f3Uarblm5E/Am0SiEF6/2My7G5NS+094+HsLW16l/dG3upl3DuaSTfBQc0heU1wWlEb
+                CBi0fc2r5z8RLHe4xmR5MwjlfeLWATnA3ifymWmR2X+sYfnnZA6/eY4+gVlukBDOpPfAIo
+                PCyEYeqqxvXqNGPzmUGxjjbB9OWgh8swAAAMEAxZAPAMpP6NYiDPNWQKRlJmxNBH5AP8nT
+                JIs994TuYbhGusphd+al9wxvG0VMO/OVH+QVzQA5LWuaLt2qTMfrulnsFLZHgmueF0uq7X
+                fk/frjm1ZY0dZnAXDsXR1ca4vM9BIwQBnEv7d8ausOBo/OezeakvuSigd+/M3RrdMsMJso
+                CpfCnbsA570+ANELDT/OXQDfvKEKtnVhAOX5jszqvvWgD5q+9Jdutt0/Rcqtg68qUCRGvR
+                vWeN+6qZf5yk3dAAAAHGphYXBASmFhcHMtTWFjQm9vay1Qcm8ubG9jYWwBAgMEBQY=
+                -----END OPENSSH PRIVATE KEY-----
+                """
+        
+        return try Insecure.RSA.PrivateKey(sshRsa: key)
+    }
+
+    func testAlgorithmNames() {
+        XCTAssertEqual(Insecure.RSA.SHA2PrivateKey<RSASHA2_256>.keyPrefix, "rsa-sha2-256")
+        XCTAssertEqual(Insecure.RSA.SHA2PublicKey<RSASHA2_256>.publicKeyPrefix, "rsa-sha2-256")
+        XCTAssertEqual(Insecure.RSA.SHA2Signature<RSASHA2_256>.signaturePrefix, "rsa-sha2-256")
+        XCTAssertEqual(Insecure.RSA.SHA2PrivateKey<RSASHA2_512>.keyPrefix, "rsa-sha2-512")
+        XCTAssertEqual(Insecure.RSA.SHA2PublicKey<RSASHA2_512>.publicKeyPrefix, "rsa-sha2-512")
+        XCTAssertEqual(Insecure.RSA.SHA2Signature<RSASHA2_512>.signaturePrefix, "rsa-sha2-512")
+    }
+
+    func testSHA256SignatureRoundTrips() throws {
+        let key = Insecure.RSA.SHA2PrivateKey<RSASHA2_256>(try makeKey())
+        let message = Array("the quick brown fox".utf8)
+        let signature = try key.signature(for: message)
+        XCTAssertTrue(key.publicKey.isValidSignature(signature, for: message))
+    }
+
+    func testSHA512SignatureRoundTrips() throws {
+        let key = Insecure.RSA.SHA2PrivateKey<RSASHA2_512>(try makeKey())
+        let message = Array("the quick brown fox".utf8)
+        let signature = try key.signature(for: message)
+        XCTAssertTrue(key.publicKey.isValidSignature(signature, for: message))
+    }
+
+    func testSignatureRejectsTamperedMessage() throws {
+        let key = Insecure.RSA.SHA2PrivateKey<RSASHA2_256>(try makeKey())
+        let signature = try key.signature(for: Array("the quick brown fox".utf8))
+        XCTAssertFalse(key.publicKey.isValidSignature(signature, for: Array("the quick brown cat".utf8)))
+    }
+
+    /// A SHA-256 signature must not verify under the SHA-512 variant, and the
+    /// wrong concrete signature type must be refused outright.
+    func testVariantsDoNotCrossVerify() throws {
+        let base = try makeKey()
+        let sha256Key = Insecure.RSA.SHA2PrivateKey<RSASHA2_256>(base)
+        let sha512Key = Insecure.RSA.SHA2PrivateKey<RSASHA2_512>(base)
+        let message = Array("the quick brown fox".utf8)
+        let signature = try sha256Key.signature(for: message)
+        XCTAssertFalse(sha512Key.publicKey.isValidSignature(signature, for: message))
+    }
+
+    /// The wire body is plain `ssh-rsa` (mpint e, mpint n) - only the algorithm
+    /// name around it changes, which is what RFC 8332 requires.
+    func testPublicKeyBodyMatchesSSHRSA() throws {
+        let base = try makeKey()
+        let sha2 = Insecure.RSA.SHA2PrivateKey<RSASHA2_256>(base).publicKey
+
+        var legacyBuffer = ByteBuffer()
+        _ = base.publicKey.write(to: &legacyBuffer)
+        var sha2Buffer = ByteBuffer()
+        _ = sha2.write(to: &sha2Buffer)
+
+        XCTAssertEqual(legacyBuffer, sha2Buffer)
+    }
+}


### PR DESCRIPTION
RSA public-key authentication currently signs with SHA-1 and offers itself as `ssh-rsa`. OpenSSH removed `ssh-rsa` from the default `PubkeyAcceptedAlgorithms` in 8.8 (2021), so an RSA key cannot authenticate against a stock modern server - the server rejects the offer and the user just sees a generic auth failure.

RFC 8332 keeps the key material identical and only changes the signature hash and the algorithm name, so this adds those two algorithms rather than touching anything existing.

### What is added

- `Sources/Citadel/Algorithms/RSASHA2.swift` - `Insecure.RSA.SHA2Signature` / `SHA2PublicKey` / `SHA2PrivateKey`, generic over an `RSASHA2Variant` (`rsa-sha2-256` → `NID_sha256`, `rsa-sha2-512` → `NID_sha512`). `SHA2PrivateKey` wraps an existing `Insecure.RSA.PrivateKey`; the public-key wire body is byte-identical to `ssh-rsa` (mpint `e`, mpint `n`), only the algorithm name around it differs.
- `SSHAuthenticationMethod.rsaSHA2(username:privateKey:includeSHA1Fallback:)` - offers `rsa-sha2-512`, then `rsa-sha2-256`, then legacy `ssh-rsa` when `includeSHA1Fallback` is true (default). It rides the delegate's existing `implementations` queue, which already pops one offer per server rejection, via a new internal `init(username:offers:)`.

Nothing existing changed: `rsa(username:privateKey:)` still behaves exactly as before, so this is additive and opt-in.

### On the wire format

swift-nio-ssh writes the userauth algorithm name and the key blob's own type from the same `publicKeyPrefix`, whereas RFC 8332 has them differ (algorithm `rsa-sha2-256`, blob still typed `ssh-rsa`). OpenSSH accepts it anyway - it resolves the blob type by name (`sshkey_type_from_name("rsa-sha2-256")` → `KEY_RSA`) rather than comparing strings, so the decoded key type matches the pkalg and verification proceeds. No swift-nio-ssh change is needed.

### Testing

- `Tests/CitadelTests/RSASHA2Tests.swift` (6 tests): sign/verify round trip for both variants, tampered-message rejection, no cross-verification between variants, algorithm names, and the public-key body matching `ssh-rsa` byte for byte.
- Verified live against Alpine OpenSSH 9.x in two configurations: a stock server (SHA-1 refused - proves the RFC 8332 path is what authenticates) and a server with `PubkeyAcceptedAlgorithms ssh-rsa,ssh-ed25519` (proves the fallback still works). Both SFTP and an interactive PTY shell.

Happy to adjust naming or the default of `includeSHA1Fallback` if you would rather have it opt-in.