### PR TITLE
Add OpenSSH private key parsing for ECDSA (P-256/384/521)

### DIFF
--- a/Sources/Citadel/OpenSSHECDSAKey.swift
+++ b/Sources/Citadel/OpenSSHECDSAKey.swift
@@ -1,0 +1,203 @@
+import Foundation
+import NIO
+import Crypto
+
+// OpenSSH private keys for the NIST curves (`ecdsa-sha2-nistp256/384/521`).
+//
+// NIOSSH already signs with P256/P384/P521 and `SSHAuthenticationMethod` already
+// exposes `.p256`/`.p384`/`.p521` — the only missing piece was reading the key
+// out of an OpenSSH key file, so an ECDSA key could not be used at all.
+//
+// Layout (RFC 5656 §3.1, as embedded by OpenSSH):
+//   public:   string "ecdsa-sha2-nistpXXX", string curve, string Q
+//   private:  string "ecdsa-sha2-nistpXXX", string curve, string Q, mpint d
+// Q is the uncompressed point (0x04 || X || Y), i.e. CryptoKit's x9.63 form.
+
+extension OpenSSH {
+    enum ECDSA {
+        /// Reads `string curve, string Q` and checks the curve matches.
+        static func readPublicComponents(
+            _ buffer: inout ByteBuffer,
+            expectedCurve: String
+        ) throws -> Data {
+            guard let curve = buffer.readSSHString(), curve == expectedCurve else {
+                throw InvalidOpenSSHKey.invalidPublicKeyPrefix
+            }
+            guard let point = buffer.readSSHBuffer(),
+                  let bytes = point.getBytes(at: 0, length: point.readableBytes) else {
+                throw InvalidOpenSSHKey.missingPublicKeyBuffer
+            }
+            return Data(bytes)
+        }
+
+        /// Reads the private half and returns (scalar `d`, point `Q`).
+        static func readPrivateComponents(
+            _ buffer: inout ByteBuffer,
+            expectedCurve: String,
+            scalarByteCount: Int
+        ) throws -> (scalar: Data, point: Data) {
+            let point = try readPublicComponents(&buffer, expectedCurve: expectedCurve)
+
+            guard let scalarBuffer = buffer.readSSHBuffer(),
+                  let scalarBytes = scalarBuffer.getBytes(at: 0, length: scalarBuffer.readableBytes) else {
+                throw InvalidOpenSSHKey.missingPrivateKeyBuffer
+            }
+
+            // `d` is an mpint: it may carry a leading 0x00 when the high bit is
+            // set, or be short when the top bytes are zero. CryptoKit wants
+            // exactly the curve's scalar width, big-endian.
+            var scalar = scalarBytes.drop { $0 == 0 }
+            guard scalar.count <= scalarByteCount else {
+                throw InvalidOpenSSHKey.invalidLayout
+            }
+            if scalar.count < scalarByteCount {
+                scalar = ([UInt8](repeating: 0, count: scalarByteCount - scalar.count) + scalar)[...]
+            }
+            return (Data(scalar), point)
+        }
+
+        /// The private scalar must actually belong to the advertised point;
+        /// mirrors the check the Ed25519 reader performs.
+        static func verify(point: Data, matches derived: Data) throws {
+            guard point == derived else {
+                throw InvalidOpenSSHKey.invalidPublicKeyInPrivateKey
+            }
+        }
+    }
+}
+
+// MARK: - P-256
+
+extension P256.Signing.PublicKey: ByteBufferConvertible {
+    static func read(consuming buffer: inout ByteBuffer) throws -> Self {
+        let point = try OpenSSH.ECDSA.readPublicComponents(&buffer, expectedCurve: "nistp256")
+        return try Self(x963Representation: point)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        // Citadel's String overload of writeSSHString returns Void; count the
+        // 4-byte length prefix ourselves.
+        buffer.writeSSHString("nistp256")
+        return 4 + "nistp256".utf8.count + buffer.writeSSHString(x963Representation)
+    }
+}
+
+extension P256.Signing.PrivateKey: OpenSSHPrivateKey {
+    typealias PublicKey = P256.Signing.PublicKey
+    static var privateKeyPrefix: String { "ecdsa-sha2-nistp256" }
+    static var publicKeyPrefix: String { "ecdsa-sha2-nistp256" }
+    static var keyType: OpenSSH.KeyType { .ecdsaP256 }
+
+    static func read(consuming buffer: inout ByteBuffer) throws -> Self {
+        let (scalar, point) = try OpenSSH.ECDSA.readPrivateComponents(
+            &buffer, expectedCurve: "nistp256", scalarByteCount: 32)
+        let key = try Self(rawRepresentation: scalar)
+        try OpenSSH.ECDSA.verify(point: point, matches: key.publicKey.x963Representation)
+        return key
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        var written = publicKey.write(to: &buffer)
+        written += buffer.writeSSHString(rawRepresentation)
+        return written
+    }
+
+    /// Creates a P-256 private key from an OpenSSH private key string.
+    /// - Parameters:
+    ///   - key: The OpenSSH private key string.
+    ///   - decryptionKey: The passphrase, if the key is encrypted.
+    public init(sshP256 key: String, decryptionKey: Data? = nil) throws {
+        self = try OpenSSH.PrivateKey<Self>(string: key, decryptionKey: decryptionKey).privateKey
+    }
+}
+
+// MARK: - P-384
+
+extension P384.Signing.PublicKey: ByteBufferConvertible {
+    static func read(consuming buffer: inout ByteBuffer) throws -> Self {
+        let point = try OpenSSH.ECDSA.readPublicComponents(&buffer, expectedCurve: "nistp384")
+        return try Self(x963Representation: point)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        // Citadel's String overload of writeSSHString returns Void; count the
+        // 4-byte length prefix ourselves.
+        buffer.writeSSHString("nistp384")
+        return 4 + "nistp384".utf8.count + buffer.writeSSHString(x963Representation)
+    }
+}
+
+extension P384.Signing.PrivateKey: OpenSSHPrivateKey {
+    typealias PublicKey = P384.Signing.PublicKey
+    static var privateKeyPrefix: String { "ecdsa-sha2-nistp384" }
+    static var publicKeyPrefix: String { "ecdsa-sha2-nistp384" }
+    static var keyType: OpenSSH.KeyType { .ecdsaP384 }
+
+    static func read(consuming buffer: inout ByteBuffer) throws -> Self {
+        let (scalar, point) = try OpenSSH.ECDSA.readPrivateComponents(
+            &buffer, expectedCurve: "nistp384", scalarByteCount: 48)
+        let key = try Self(rawRepresentation: scalar)
+        try OpenSSH.ECDSA.verify(point: point, matches: key.publicKey.x963Representation)
+        return key
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        var written = publicKey.write(to: &buffer)
+        written += buffer.writeSSHString(rawRepresentation)
+        return written
+    }
+
+    /// Creates a P-384 private key from an OpenSSH private key string.
+    public init(sshP384 key: String, decryptionKey: Data? = nil) throws {
+        self = try OpenSSH.PrivateKey<Self>(string: key, decryptionKey: decryptionKey).privateKey
+    }
+}
+
+// MARK: - P-521
+
+extension P521.Signing.PublicKey: ByteBufferConvertible {
+    static func read(consuming buffer: inout ByteBuffer) throws -> Self {
+        let point = try OpenSSH.ECDSA.readPublicComponents(&buffer, expectedCurve: "nistp521")
+        return try Self(x963Representation: point)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        // Citadel's String overload of writeSSHString returns Void; count the
+        // 4-byte length prefix ourselves.
+        buffer.writeSSHString("nistp521")
+        return 4 + "nistp521".utf8.count + buffer.writeSSHString(x963Representation)
+    }
+}
+
+extension P521.Signing.PrivateKey: OpenSSHPrivateKey {
+    typealias PublicKey = P521.Signing.PublicKey
+    static var privateKeyPrefix: String { "ecdsa-sha2-nistp521" }
+    static var publicKeyPrefix: String { "ecdsa-sha2-nistp521" }
+    static var keyType: OpenSSH.KeyType { .ecdsaP521 }
+
+    // P-521 scalars are 66 bytes (521 bits rounded up).
+    static func read(consuming buffer: inout ByteBuffer) throws -> Self {
+        let (scalar, point) = try OpenSSH.ECDSA.readPrivateComponents(
+            &buffer, expectedCurve: "nistp521", scalarByteCount: 66)
+        let key = try Self(rawRepresentation: scalar)
+        try OpenSSH.ECDSA.verify(point: point, matches: key.publicKey.x963Representation)
+        return key
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        var written = publicKey.write(to: &buffer)
+        written += buffer.writeSSHString(rawRepresentation)
+        return written
+    }
+
+    /// Creates a P-521 private key from an OpenSSH private key string.
+    public init(sshP521 key: String, decryptionKey: Data? = nil) throws {
+        self = try OpenSSH.PrivateKey<Self>(string: key, decryptionKey: decryptionKey).privateKey
+    }
+}

--- a/Sources/Citadel/OpenSSHKey.swift
+++ b/Sources/Citadel/OpenSSHKey.swift
@@ -287,6 +287,9 @@ enum OpenSSH {
     enum KeyType: String {
         case sshRSA = "ssh-rsa"
         case sshED25519 = "ssh-ed25519"
+        case ecdsaP256 = "ecdsa-sha2-nistp256"
+        case ecdsaP384 = "ecdsa-sha2-nistp384"
+        case ecdsaP521 = "ecdsa-sha2-nistp521"
     }
     
     struct PrivateKey<SSHKey: OpenSSHPrivateKey> {

--- a/Tests/CitadelTests/OpenSSHECDSAKeyTests.swift
+++ b/Tests/CitadelTests/OpenSSHECDSAKeyTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import XCTest
+import Crypto
+import Citadel
+import NIO
+
+/// OpenSSH ECDSA private keys (`ecdsa-sha2-nistp256/384/521`).
+/// The keys below are throwaway vectors generated for this test only - they
+/// authenticate nothing.
+final class OpenSSHECDSAKeyTests: XCTestCase {
+
+    private let p256 = """
+            -----BEGIN OPENSSH PRIVATE KEY-----
+            b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS
+            1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQRa23aG4sj7RXI1VXqNqwCXZGQ5a3n1
+            j2icmd6WIMJzb+0FtoItsxcUdaJQABwtol5ZyLaKHOerJ9QNehWmcpgrAAAAqJBMpbaQTK
+            W2AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFrbdobiyPtFcjVV
+            eo2rAJdkZDlrefWPaJyZ3pYgwnNv7QW2gi2zFxR1olAAHC2iXlnItooc56sn1A16FaZymC
+            sAAAAhAK1VgLgn/t4/wOTbjuNL25bGRLoZGtTDwFUr+hRHMU8pAAAADGNpdGFkZWwtdGVz
+            dAECAw==
+            -----END OPENSSH PRIVATE KEY-----
+            """
+
+    private let p384 = """
+            -----BEGIN OPENSSH PRIVATE KEY-----
+            b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAiAAAABNlY2RzYS
+            1zaGEyLW5pc3RwMzg0AAAACG5pc3RwMzg0AAAAYQQtlFE8HrVfmCyA5t51zcyPWadnAavt
+            DzFk5GJ/KMbtGQ/8/Ok5zQjsd5AmW5InBvGXAGTmWJhBkGxYe+BIdYqNlBB4vYt6lmQ0/N
+            nTZ3zmWzKxUOnCtrY7xkg92unClh4AAADYw1KteMNSrXgAAAATZWNkc2Etc2hhMi1uaXN0
+            cDM4NAAAAAhuaXN0cDM4NAAAAGEELZRRPB61X5gsgObedc3Mj1mnZwGr7Q8xZORifyjG7R
+            kP/PzpOc0I7HeQJluSJwbxlwBk5liYQZBsWHvgSHWKjZQQeL2LepZkNPzZ02d85lsysVDp
+            wra2O8ZIPdrpwpYeAAAAMQCvBlbeS0zOSHzkhVB6pJtvP4fu5IW47X9JV3ZWECGca92Wvs
+            I/tGt/OsD4Why7vpoAAAAMY2l0YWRlbC10ZXN0AQID
+            -----END OPENSSH PRIVATE KEY-----
+            """
+
+    private let p521 = """
+            -----BEGIN OPENSSH PRIVATE KEY-----
+            b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAArAAAABNlY2RzYS
+            1zaGEyLW5pc3RwNTIxAAAACG5pc3RwNTIxAAAAhQQB/tGzj/x26TTy6Dk9ymbDfp00Q9i5
+            odPRyHFqDTOJxNzzFw/iBScWD+P0zZLkx0m0S7wmlItqTdlslXCR3eaduzUA7VWn/h5xCf
+            5ttxXDBlqf052/wtpxWQFLHv0twifC2ljfDDnOv3UhjEPfCueFORn6jTTDh7Poer6yKvsq
+            rKX+JiEAAAEQjFvt5Yxb7eUAAAATZWNkc2Etc2hhMi1uaXN0cDUyMQAAAAhuaXN0cDUyMQ
+            AAAIUEAf7Rs4/8duk08ug5Pcpmw36dNEPYuaHT0chxag0zicTc8xcP4gUnFg/j9M2S5MdJ
+            tEu8JpSLak3ZbJVwkd3mnbs1AO1Vp/4ecQn+bbcVwwZan9Odv8LacVkBSx79LcInwtpY3w
+            w5zr91IYxD3wrnhTkZ+o00w4ez6Hq+sir7Kqyl/iYhAAAAQSbO0DyxJNZTPylT73uwR6Qj
+            QNt34jP9zOav2aKCc5dpnkkACg4/z5XUg9axi6P6lv9J2mKMZHlluVNsyXLCPSBNAAAADG
+            NpdGFkZWwtdGVzdAECAwQFBgc=
+            -----END OPENSSH PRIVATE KEY-----
+            """
+
+    private let p256Locked = """
+            -----BEGIN OPENSSH PRIVATE KEY-----
+            b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABDGhkt689
+            5qHcM0rltyy4bnAAAAGAAAAAEAAABoAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlz
+            dHAyNTYAAABBBB5CxY1tcGOyNL/gJKttACXoybs8c1VFF5bF5VPKl14tNstUJ8xkaruXWT
+            Lm5PPLKZGZGWbMv6NGeHDhmaOwQyoAAACw0hANbe8ThqU0EbyqJIobErDaSUEdCWgsr4nN
+            h+uRpvedQECYZx7EZ7aPgAMEbeKOYSCLV7cwYamlgsxMFskPeWCe8oGbqE1PuQQl1VxmME
+            w2RcuKsL3RlL+UI9OOk9gfu4D6F34+phQQZ0jWDgIOcEVMU5l+n4wwjCVs8AGmpLvNapbV
+            A0kIiPg5IlL5kD7cGrDkHG+HFIXFtYbSB8lT/xdEilZIcrxN/fzO69GD4LQ=
+            -----END OPENSSH PRIVATE KEY-----
+            """
+
+
+    func testParseP256() throws {
+        let key = try P256.Signing.PrivateKey(sshP256: p256)
+        XCTAssertEqual(key.publicKey.x963Representation.count, 65)
+        // The parsed scalar must reproduce the point stored in the key file.
+        XCTAssertEqual(Data(base64Encoded: "BFrbdobiyPtFcjVVeo2rAJdkZDlrefWPaJyZ3pYgwnNv7QW2gi2zFxR1olAAHC2iXlnItooc56sn1A16FaZymCs=")!, key.publicKey.x963Representation)
+    }
+
+    func testParseP384() throws {
+        let key = try P384.Signing.PrivateKey(sshP384: p384)
+        XCTAssertEqual(key.publicKey.x963Representation.count, 97)
+    }
+
+    func testParseP521() throws {
+        let key = try P521.Signing.PrivateKey(sshP521: p521)
+        XCTAssertEqual(key.publicKey.x963Representation.count, 133)
+    }
+
+    func testParseEncryptedP256() throws {
+        let key = try P256.Signing.PrivateKey(
+            sshP256: p256Locked, decryptionKey: Data("test-passphrase".utf8))
+        XCTAssertEqual(key.publicKey.x963Representation.count, 65)
+    }
+
+    func testWrongPassphraseFails() {
+        XCTAssertThrowsError(try P256.Signing.PrivateKey(
+            sshP256: p256Locked, decryptionKey: Data("not-the-passphrase".utf8)))
+    }
+
+    func testCurveMismatchIsRejected() {
+        // A P-384 key must not parse as P-256: the embedded curve name differs.
+        XCTAssertThrowsError(try P256.Signing.PrivateKey(sshP256: p384))
+    }
+
+    func testSignatureRoundTripsAfterParsing() throws {
+        let key = try P256.Signing.PrivateKey(sshP256: p256)
+        let message = Data("the quick brown fox".utf8)
+        let signature = try key.signature(for: message)
+        XCTAssertTrue(key.publicKey.isValidSignature(signature, for: message))
+    }
+}


### PR DESCRIPTION
NIOSSH already signs with the NIST curves and `SSHAuthenticationMethod` already exposes `.p256` / `.p384` / `.p521`, but there is no way to read such a key out of an OpenSSH key file: `OpenSSHPrivateKey` is implemented only for `Curve25519.Signing.PrivateKey` and `Insecure.RSA.PrivateKey`. So an `ecdsa-sha2-nistp*` key cannot be used at all, even though everything downstream supports it.

### What is added

`Sources/Citadel/OpenSSHECDSAKey.swift`:

- `OpenSSHPrivateKey` / `ByteBufferConvertible` conformances for `P256`, `P384` and `P521` `Signing.PrivateKey` (and their public keys).
- `public init(sshP256:decryptionKey:)`, `sshP384:`, `sshP521:`, matching the existing `sshEd25519:` / `sshRsa:` initializers.
- Three cases on the internal `OpenSSH.KeyType` enum.

Two details worth a careful look in review:

- **mpint normalisation.** OpenSSH stores `d` as an mpint, so it can carry a leading `0x00` when the high bit is set, or be shorter than the curve width when the top bytes are zero. CryptoKit wants exactly the curve width, big-endian, so the reader strips leading zeros and re-pads. P-521 is 66 bytes.
- **Consistency check.** The parsed scalar must reproduce the point stored in the key file, mirroring the public-key-in-private-key check the Ed25519 reader performs. A wrong curve is rejected via the embedded curve name.

Nothing existing was changed - purely additive.

### Testing

`Tests/CitadelTests/OpenSSHECDSAKeyTests.swift` (7 tests): each of the three curves, an encrypted key, a wrong passphrase, curve mismatch (a P-384 key must not parse as P-256), and a sign/verify round trip after parsing. The embedded keys are throwaway vectors generated for the test.

Also exercised end to end against OpenSSH 9.x (SFTP listing + interactive PTY shell) with all three curves, including a server with `PasswordAuthentication no`.

Note: `Citadel2Tests.testSFTPUpload` fails locally with `bind: Address already in use` on port 2345 - it fails the same way on an untouched `0.12.1` checkout, so it looks unrelated.

Separate from #135 (rsa-sha2), which is now RSA-only again so the two can be reviewed independently.