### PR TITLE
SFTP: add SSH_FXP_EXTENDED / SSH_FXP_EXTENDED_REPLY support

### DIFF
--- a/Sources/Citadel/SFTP/Client/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/Client/SFTPClient.swift
@@ -448,6 +448,51 @@ public final class SFTPClient: Sendable {
         return realpath.path
     }
 
+    /// Send an `SSH_FXP_EXTENDED` request (draft-ietf-secsh-filexfer-02 §6.11).
+    ///
+    /// - Parameters:
+    ///   - name: The extension name, e.g. `posix-rename@openssh.com`, `statvfs@openssh.com`.
+    ///   - payload: The extension-specific request data that follows the name.
+    /// - Returns: `.status` when the server answers with `SSH_FXP_STATUS` (only `.ok`/`.eof` reach the
+    ///   caller — any other status is thrown as `SFTPMessage.Status`), or `.reply(payload)` when it answers
+    ///   with `SSH_FXP_EXTENDED_REPLY`.
+    /// - Throws: `SFTPMessage.Status` for an error status; `SFTPError.invalidResponse` for a protocol error.
+    ///
+    /// ## Example
+    /// ```swift
+    /// // Atomic rename-onto-existing (OpenSSH): the plain SSH_FXP_RENAME refuses an existing target.
+    /// var payload = ByteBuffer()
+    /// payload.writeSSHString("staging.tmp")
+    /// payload.writeSSHString("final.txt")
+    /// _ = try await sftp.sendExtendedRequest("posix-rename@openssh.com", payload: payload)
+    /// ```
+    public func sendExtendedRequest(_ name: String, payload: ByteBuffer) async throws -> SFTPExtendedResponse {
+        self.logger.info("SFTP requesting extension '\(name)'")
+
+        let response = try await sendRequest(.extended(.init(
+            requestId: allocateRequestId(),
+            name: name,
+            payload: payload
+        )))
+
+        switch response {
+        case .status(let status):
+            return .status(status)
+        case .extendedReply(let reply):
+            return .reply(reply.payload)
+        default:
+            self.logger.warning("SFTP server returned bad response to extended request, this is a protocol error")
+            throw SFTPError.invalidResponse
+        }
+    }
+}
+
+/// The server's answer to an `SSH_FXP_EXTENDED` request.
+public enum SFTPExtendedResponse: Sendable {
+    /// Answered with `SSH_FXP_STATUS` (`.ok` or `.eof`).
+    case status(SFTPMessage.Status)
+    /// Answered with `SSH_FXP_EXTENDED_REPLY`; the extension-specific payload.
+    case reply(ByteBuffer)
 }
 
 extension SSHClient {

--- a/Sources/Citadel/SFTP/SFTPMessage.swift
+++ b/Sources/Citadel/SFTP/SFTPMessage.swift
@@ -37,6 +37,7 @@ enum SFTPRequest: CustomDebugStringConvertible, Sendable {
     case rename(SFTPMessage.Rename)
     case fsetstat(SFTPMessage.FileSetStat)
     case setstat(SFTPMessage.SetStat)
+    case extended(SFTPMessage.Extended)
 
     var requestId: UInt32 {
         get {
@@ -70,6 +71,8 @@ enum SFTPRequest: CustomDebugStringConvertible, Sendable {
             case .fsetstat(let message):
                 return message.requestId
             case .setstat(let message):
+                return message.requestId
+            case .extended(let message):
                 return message.requestId
             }
         }
@@ -107,6 +110,8 @@ enum SFTPRequest: CustomDebugStringConvertible, Sendable {
             return .fsetstat(message)
         case .setstat(let message):
             return .setstat(message)
+        case .extended(let message):
+            return .extended(message)
         }
     }
     
@@ -127,6 +132,7 @@ enum SFTPRequest: CustomDebugStringConvertible, Sendable {
         case .rename(let message): return message.debugDescription
         case .fsetstat(let message): return message.debugDescription
         case .setstat(let message): return message.debugDescription
+        case .extended(let message): return message.debugDescription
         }
     }
 }
@@ -140,6 +146,7 @@ enum SFTPResponse: Sendable {
     case attributes(SFTPMessage.Attributes)
     case fsetstat(SFTPMessage.FileSetStat)
     case setstat(SFTPMessage.SetStat)
+    case extendedReply(SFTPMessage.ExtendedReply)
     
     var requestId: UInt32 {
         get {
@@ -159,6 +166,8 @@ enum SFTPResponse: Sendable {
             case .fsetstat(let message):
                 return message.requestId
             case .setstat(let message):
+                return message.requestId
+            case .extendedReply(let message):
                 return message.requestId
             }
         }
@@ -182,6 +191,8 @@ enum SFTPResponse: Sendable {
             return .fsetstat(message)
         case .setstat(let message):
             return .setstat(message)
+        case .extendedReply(let message):
+            return .extendedReply(message)
         }
     }
     
@@ -203,7 +214,9 @@ enum SFTPResponse: Sendable {
             self = .fsetstat(message)
         case .setstat(let message):
             self = .setstat(message)
-        case .realpath, .openFile, .fstat, .closeFile, .read, .write, .initialize, .version, .stat, .lstat, .rmdir, .opendir, .readdir, .remove, .symlink, .readlink, .rename:
+        case .extendedReply(let message):
+            self = .extendedReply(message)
+        case .realpath, .openFile, .fstat, .closeFile, .read, .write, .initialize, .version, .stat, .lstat, .rmdir, .opendir, .readdir, .remove, .symlink, .readlink, .rename, .extended:
             return nil
         }
     }
@@ -218,6 +231,7 @@ enum SFTPResponse: Sendable {
         case .attributes(let message): return message.debugDescription
         case .fsetstat(let message): return message.debugDescription
         case .setstat(let message): return message.debugDescription
+        case .extendedReply(let message): return message.debugDescription
         }
     }
 }
@@ -363,6 +377,31 @@ public enum SFTPMessage: Sendable {
         
         public var debugDescription: String { "{\(self.requestId)}(\(self.path),\(self.attributes)" }
         fileprivate var debugVariantWithoutLargeData: Self { self }
+    }
+
+    /// `SSH_FXP_EXTENDED` (draft-ietf-secsh-filexfer-02 §6.11) — a vendor extension request such as
+    /// `posix-rename@openssh.com`. `payload` is the extension-specific data following the name.
+    public struct Extended: SFTPMessageContent, Sendable {
+        public static let id = SFTPMessageType.extended
+
+        public let requestId: UInt32
+        public let name: String
+        public var payload: ByteBuffer
+
+        public var debugDescription: String { "{\(self.requestId)}(\(self.name), <\(payload.readableBytes) bytes>)" }
+        fileprivate var debugVariantWithoutLargeData: Self { .init(requestId: self.requestId, name: self.name, payload: .init()) }
+    }
+
+    /// `SSH_FXP_EXTENDED_REPLY` — the extension-specific reply. Extensions answered by a plain
+    /// `SSH_FXP_STATUS` (e.g. `posix-rename@openssh.com`) never produce this message.
+    public struct ExtendedReply: SFTPMessageContent, Sendable {
+        public static let id = SFTPMessageType.extendedReply
+
+        public let requestId: UInt32
+        public var payload: ByteBuffer
+
+        public var debugDescription: String { "{\(self.requestId)}(<\(payload.readableBytes) bytes>)" }
+        fileprivate var debugVariantWithoutLargeData: Self { .init(requestId: self.requestId, payload: .init()) }
     }
 
     public struct Rename: SFTPMessageContent, Sendable {
@@ -583,6 +622,8 @@ public enum SFTPMessage: Sendable {
     case attributes(Attributes)
     case readdir(ReadDir)
     case rename(Rename)
+    case extended(Extended)
+    case extendedReply(ExtendedReply)
     
     public var messageType: SFTPMessageType {
         switch self {
@@ -611,7 +652,9 @@ public enum SFTPMessage: Sendable {
                 .setstat(let message as SFTPMessageContent),
                 .symlink(let message as SFTPMessageContent),
                 .readlink(let message as SFTPMessageContent),
-                .rename(let message as SFTPMessageContent):
+                .rename(let message as SFTPMessageContent),
+                .extended(let message as SFTPMessageContent),
+                .extendedReply(let message as SFTPMessageContent):
             return message.id
         }
     }
@@ -643,7 +686,9 @@ public enum SFTPMessage: Sendable {
                 .setstat(let message as SFTPMessageContent),
                 .symlink(let message as SFTPMessageContent),
                 .readlink(let message as SFTPMessageContent),
-                .rename(let message as SFTPMessageContent):
+                .rename(let message as SFTPMessageContent),
+                .extended(let message as SFTPMessageContent),
+                .extendedReply(let message as SFTPMessageContent):
             return "\(message.id)\(message.debugDescription)"
         }
     }
@@ -675,6 +720,8 @@ public enum SFTPMessage: Sendable {
         case .symlink(let message): return Self.symlink(message.debugVariantWithoutLargeData)
         case .readlink(let message): return Self.readlink(message.debugVariantWithoutLargeData)
         case .rename(let message): return Self.rename(message.debugVariantWithoutLargeData)
+        case .extended(let message): return Self.extended(message.debugVariantWithoutLargeData)
+        case .extendedReply(let message): return Self.extendedReply(message.debugVariantWithoutLargeData)
         }
     }
     

--- a/Sources/Citadel/SFTP/SFTPMessageParser.swift
+++ b/Sources/Citadel/SFTP/SFTPMessageParser.swift
@@ -423,8 +423,32 @@ struct SFTPMessageParser: ByteToMessageDecoder {
                     targetPath: targetPath
                 )
             )
-        case .extended, .extendedReply:
-            throw SFTPError.invalidPayload(type: type)
+        case .extended:
+            guard
+                let requestId = payload.readInteger(as: UInt32.self),
+                let name = payload.readSSHString()
+            else {
+                throw SFTPError.invalidPayload(type: type)
+            }
+
+            message = .extended(
+                .init(
+                    requestId: requestId,
+                    name: name,
+                    payload: payload.readSlice(length: payload.readableBytes) ?? .init()
+                )
+            )
+        case .extendedReply:
+            guard let requestId = payload.readInteger(as: UInt32.self) else {
+                throw SFTPError.invalidPayload(type: type)
+            }
+
+            message = .extendedReply(
+                .init(
+                    requestId: requestId,
+                    payload: payload.readSlice(length: payload.readableBytes) ?? .init()
+                )
+            )
         }
         
         context.fireChannelRead(wrapInboundOut(message))

--- a/Sources/Citadel/SFTP/SFTPSerializer.swift
+++ b/Sources/Citadel/SFTP/SFTPSerializer.swift
@@ -125,6 +125,15 @@ final class SFTPMessageSerializer: MessageToByteEncoder {
             out.writeInteger(SFTPMessage.Symlink.id.rawValue)
             out.writeInteger(readlink.requestId)
             out.writeSSHString(readlink.path)
+        case .extended(var extended):
+            out.writeInteger(SFTPMessage.Extended.id.rawValue)
+            out.writeInteger(extended.requestId)
+            out.writeSSHString(extended.name)
+            out.writeBuffer(&extended.payload)
+        case .extendedReply(var reply):
+            out.writeInteger(SFTPMessage.ExtendedReply.id.rawValue)
+            out.writeInteger(reply.requestId)
+            out.writeBuffer(&reply.payload)
         case .rename(let rename):
             out.writeInteger(SFTPMessage.Rename.id.rawValue)
             out.writeInteger(rename.requestId)

--- a/Sources/Citadel/SFTP/Server/SFTPServerInboundHandler.swift
+++ b/Sources/Citadel/SFTP/Server/SFTPServerInboundHandler.swift
@@ -580,7 +580,20 @@ final class SFTPServerInboundHandler: ChannelInboundHandler {
             readlink(command: command, context: context)
         case .rename(let command):
             rename(command: command, context: context)
-        case .version, .handle, .status, .data, .attributes, .name:
+        case .extended(let command):
+            // No extensions are implemented server-side; answer per the protocol instead of dropping the channel.
+            context.channel.writeAndFlush(
+                SFTPMessage.status(
+                    SFTPMessage.Status(
+                        requestId: command.requestId,
+                        errorCode: .unsupportedOperation,
+                        message: "Extension not supported",
+                        languageTag: "EN"
+                    )
+                ),
+                promise: nil
+            )
+        case .version, .handle, .status, .data, .attributes, .name, .extendedReply:
             // Client cannot send these messages
             context.channel.triggerUserOutboundEvent(ChannelFailureEvent()).whenComplete { _ in
                 context.channel.close(promise: nil)

--- a/Tests/CitadelTests/SFTPExtendedMessageTests.swift
+++ b/Tests/CitadelTests/SFTPExtendedMessageTests.swift
@@ -1,0 +1,69 @@
+import NIO
+import XCTest
+@testable import Citadel
+
+/// Round-trip tests for `SSH_FXP_EXTENDED` / `SSH_FXP_EXTENDED_REPLY` through the real
+/// serializer and parser, using `EmbeddedChannel` — no server required.
+final class SFTPExtendedMessageTests: XCTestCase {
+    private func roundTrip(_ message: SFTPMessage) throws -> (wire: ByteBuffer, parsed: SFTPMessage) {
+        let outbound = EmbeddedChannel(handler: MessageToByteHandler(SFTPMessageSerializer()))
+        try outbound.writeOutbound(message)
+        let wire = try XCTUnwrap(try outbound.readOutbound(as: ByteBuffer.self))
+
+        let inbound = EmbeddedChannel(handler: ByteToMessageHandler(SFTPMessageParser()))
+        try inbound.writeInbound(wire)
+        let parsed = try XCTUnwrap(try inbound.readInbound(as: SFTPMessage.self))
+        return (wire, parsed)
+    }
+
+    func testExtendedRequestRoundTripsThroughSerializerAndParser() throws {
+        var payload = ByteBufferAllocator().buffer(capacity: 64)
+        for path in ["/a/old.txt", "/a/new.txt"] {
+            payload.writeInteger(UInt32(path.utf8.count))
+            payload.writeString(path)
+        }
+
+        let sent = SFTPMessage.Extended(requestId: 3, name: "posix-rename@openssh.com", payload: payload)
+        let (wire, parsed) = try roundTrip(.extended(sent))
+
+        // Wire format: uint32 length · byte 200 (SSH_FXP_EXTENDED) · uint32 request-id · string name · data
+        XCTAssertEqual(wire.getInteger(at: wire.readerIndex, as: UInt32.self), UInt32(wire.readableBytes - 4))
+        XCTAssertEqual(wire.getInteger(at: wire.readerIndex + 4, as: UInt8.self), SFTPMessageType.extended.rawValue)
+
+        guard case .extended(let received) = parsed else {
+            return XCTFail("parsed as \(parsed.debugDescription), expected .extended")
+        }
+        XCTAssertEqual(received.requestId, sent.requestId)
+        XCTAssertEqual(received.name, sent.name)
+        XCTAssertEqual(received.payload, payload)
+    }
+
+    func testExtendedReplyRoundTripsThroughSerializerAndParser() throws {
+        var payload = ByteBufferAllocator().buffer(capacity: 16)
+        payload.writeInteger(UInt64(4096)) // e.g. the first field of a statvfs@openssh.com reply
+        payload.writeInteger(UInt64(1024))
+
+        let sent = SFTPMessage.ExtendedReply(requestId: 7, payload: payload)
+        let (wire, parsed) = try roundTrip(.extendedReply(sent))
+
+        XCTAssertEqual(wire.getInteger(at: wire.readerIndex + 4, as: UInt8.self), SFTPMessageType.extendedReply.rawValue)
+
+        guard case .extendedReply(let received) = parsed else {
+            return XCTFail("parsed as \(parsed.debugDescription), expected .extendedReply")
+        }
+        XCTAssertEqual(received.requestId, sent.requestId)
+        XCTAssertEqual(received.payload, payload)
+    }
+
+    func testExtendedRequestWithEmptyPayloadRoundTrips() throws {
+        let sent = SFTPMessage.Extended(requestId: 9, name: "fsync@openssh.com", payload: ByteBuffer())
+        let (_, parsed) = try roundTrip(.extended(sent))
+
+        guard case .extended(let received) = parsed else {
+            return XCTFail("parsed as \(parsed.debugDescription), expected .extended")
+        }
+        XCTAssertEqual(received.requestId, 9)
+        XCTAssertEqual(received.name, "fsync@openssh.com")
+        XCTAssertEqual(received.payload.readableBytes, 0)
+    }
+}


### PR DESCRIPTION
This adds support for the SFTP extension mechanism (draft-ietf-secsh-filexfer §"Extensions", message types `SSH_FXP_EXTENDED` 200 / `SSH_FXP_EXTENDED_REPLY` 201), which Citadel currently can neither send nor parse.

**Client:** a new `SFTPClient.sendExtendedRequest(_:payload:)` sends a named extended request with an opaque payload and returns `SFTPExtendedResponse` — `.status` for extensions that answer with a status (e.g. `posix-rename@openssh.com`), `.reply(payload)` for those that return data (e.g. `statvfs@openssh.com`).

**Parser/serializer:** both message types are now round-tripped; the parser previously threw `.unknownMessage` on either, so a server-initiated `SSH_FXP_EXTENDED_REPLY` killed the channel.

**Server:** a received `SSH_FXP_EXTENDED` is answered with `SSH_FX_OP_UNSUPPORTED` rather than dropping the connection — honest refusal instead of a hang.

Motivation: OpenSSH's widely deployed extensions — `posix-rename@openssh.com` (atomic rename-onto-existing; plain `SSH_FXP_RENAME` refuses when the target exists), `hardlink@openssh.com`, `fsync@openssh.com`, `statvfs@openssh.com`. We use `posix-rename` in production against OpenSSH servers via this patch.

Round-trip tests for both message types included (`SFTPExtendedMessageTests`, EmbeddedChannel — no server required).

No changes to existing API; additive only.
